### PR TITLE
Add output format option for GitHub annotations

### DIFF
--- a/src/GLuaFixer/LintMain.hs
+++ b/src/GLuaFixer/LintMain.hs
@@ -93,12 +93,12 @@ lint ls (f : fs) = do
         else if f == "stdin" then do
             msgs <- lintFile config f <$> getContents
 
-            mapM_ print msgs
+            mapM_ (\x -> print (formatLintMessage x (log_format config))) msgs
             pure $ not $ null msgs
         else do
             msgs <- lintFile config f <$> doReadFile f
 
-            mapM_ print msgs
+            mapM_ (\x -> print (formatLintMessage x (log_format config))) msgs
             pure $ not $ null msgs
 
     -- Lint the other files

--- a/src/GLuaFixer/LintMessage.hs
+++ b/src/GLuaFixer/LintMessage.hs
@@ -1,10 +1,30 @@
+{-# LANGUAGE OverloadedStrings #-}
 module GLuaFixer.LintMessage where
 
 import GLua.AG.Token
 import GLua.AG.PrettyPrint
+import Data.Aeson
+import Control.Monad
 import Data.Char
 import Data.List (sortOn)
 import Text.ParserCombinators.UU.BasicInstances hiding (msgs)
+
+data LogFormat = StandardLogFormat | GithubLogFormat
+
+instance Show LogFormat where
+  show (StandardLogFormat) = "standard"
+  show (GithubLogFormat) = "github"
+
+instance ToJSON LogFormat where
+  toJSON StandardLogFormat = "standard"
+  toJSON GithubLogFormat = "github"
+
+instance FromJSON LogFormat where
+  parseJSON (String logFormat) = case logFormat of
+    "standard" -> return ( StandardLogFormat )
+    "github" -> return ( GithubLogFormat )
+    _ -> fail ( "Please use either \"standard\" or \"github\" but was " ++ show logFormat )
+  parseJSON _ = mzero
 
 -- | Represents lint messages
 data LintMessage
@@ -15,10 +35,10 @@ data LintMessage
 instance Show LintMessage where
     show lintMsg = formatLintMessageDefault lintMsg
 
-formatLintMessage :: LintMessage -> String -> String
+formatLintMessage :: LintMessage -> LogFormat -> String
 formatLintMessage lintMsg format = do
   case format of
-    "github" -> formatLintMessageGithub lintMsg
+    GithubLogFormat -> formatLintMessageGithub lintMsg
     _ -> formatLintMessageDefault lintMsg
 
 formatLintMessageDefault :: LintMessage -> String

--- a/src/GLuaFixer/LintMessage.hs
+++ b/src/GLuaFixer/LintMessage.hs
@@ -36,17 +36,16 @@ instance Show LintMessage where
     show lintMsg = formatLintMessageDefault lintMsg
 
 formatLintMessage :: LintMessage -> LogFormat -> String
-formatLintMessage lintMsg format = do
-  case format of
-    GithubLogFormat -> formatLintMessageGithub lintMsg
-    _ -> formatLintMessageDefault lintMsg
+formatLintMessage lintMsg GithubLogFormat = formatLintMessageGithub lintMsg
+formatLintMessage lintMsg _ = formatLintMessageDefault lintMsg
 
 formatLintMessageDefault :: LintMessage -> String
-formatLintMessageDefault lintMsg = do
+formatLintMessageDefault lintMsg =
   let (rg, msg, file, level) = case lintMsg of
         LintError _rg _msg _file -> (_rg, _msg, _file, "Error")
         LintWarning _rg _msg _file -> (_rg, _msg, _file, "Warning")
-  file ++ ": [" ++ level ++ "] " ++ (renderRegion rg) ++ ": " ++ msg
+  in
+    file ++ ": [" ++ level ++ "] " ++ (renderRegion rg) ++ ": " ++ msg
 
 formatLintMessageGithub :: LintMessage -> String
 formatLintMessageGithub lintMsg = do

--- a/src/GLuaFixer/LintMessage.hs
+++ b/src/GLuaFixer/LintMessage.hs
@@ -13,25 +13,26 @@ data LintMessage
   deriving ( Eq )
 
 instance Show LintMessage where
-    show (LintError rg msg file) = formatLintMessageDefault "Error" rg msg file
-    show (LintWarning rg msg file) = formatLintMessageDefault "Warning" rg msg file
-
-getLintMessageData :: LintMessage -> (Region, String, String, String)
-getLintMessageData (LintError rg msg file) = (rg, msg, file, "Error")
-getLintMessageData (LintWarning rg msg file) = (rg, msg, file, "Warning")
+    show lintMsg = formatLintMessageDefault lintMsg
 
 formatLintMessage :: LintMessage -> String -> String
 formatLintMessage lintMsg format = do
-  let (rg, msg, file, level) = getLintMessageData lintMsg
   case format of
-    "github" -> formatLintMessageGithub level rg msg file
-    _ -> formatLintMessageDefault level rg msg file
+    "github" -> formatLintMessageGithub lintMsg
+    _ -> formatLintMessageDefault lintMsg
 
-formatLintMessageDefault :: String -> Region -> String -> String -> String
-formatLintMessageDefault level rg msg file = file ++ ": [" ++ level ++ "] " ++ (renderRegion rg) ++ ": " ++ msg
+formatLintMessageDefault :: LintMessage -> String
+formatLintMessageDefault lintMsg = do
+  let (rg, msg, file, level) = case lintMsg of
+        LintError _rg _msg _file -> (_rg, _msg, _file, "Error")
+        LintWarning _rg _msg _file -> (_rg, _msg, _file, "Warning")
+  file ++ ": [" ++ level ++ "] " ++ (renderRegion rg) ++ ": " ++ msg
 
-formatLintMessageGithub :: String -> Region -> String -> String -> String
-formatLintMessageGithub level rg msg file = do
+formatLintMessageGithub :: LintMessage -> String
+formatLintMessageGithub lintMsg = do
+  let (rg, msg, file, level) = case lintMsg of
+        LintError _rg _msg _file -> (_rg, _msg, _file, "Error")
+        LintWarning _rg _msg _file -> (_rg, _msg, _file, "Warning")
   let (Region start _) = rg
   let (LineColPos line col _) = start
   "::" ++ map toLower level ++ " file=" ++ file ++ ",line=" ++ show (succ line) ++ ",col=" ++ show (succ col) ++ "::" ++ msg

--- a/src/GLuaFixer/LintMessage.hs
+++ b/src/GLuaFixer/LintMessage.hs
@@ -2,17 +2,39 @@ module GLuaFixer.LintMessage where
 
 import GLua.AG.Token
 import GLua.AG.PrettyPrint
+import Data.Char
 import Data.List (sortOn)
+import Text.ParserCombinators.UU.BasicInstances hiding (msgs)
 
 -- | Represents lint messages
 data LintMessage
   = LintError { err_rg :: Region, err_msg :: String, err_file :: String }
-  | LintWarning {warn_rg :: Region, warn_msg :: String, warn_file :: String }
+  | LintWarning { warn_rg :: Region, warn_msg :: String, warn_file :: String }
   deriving ( Eq )
 
 instance Show LintMessage where
-    show (LintError rg msg file) = showString file . showString ": [Error] " . showString (renderRegion rg) . showString ": " . showString msg $ ""
-    show (LintWarning rg msg file) = showString file . showString ": [Warning] " . showString (renderRegion rg) . showString ": " . showString msg $ ""
+    show (LintError rg msg file) = formatLintMessageDefault "Error" rg msg file
+    show (LintWarning rg msg file) = formatLintMessageDefault "Warning" rg msg file
+
+getLintMessageData :: LintMessage -> (Region, String, String, String)
+getLintMessageData (LintError rg msg file) = (rg, msg, file, "Error")
+getLintMessageData (LintWarning rg msg file) = (rg, msg, file, "Warning")
+
+formatLintMessage :: LintMessage -> String -> String
+formatLintMessage lintMsg format = do
+  let (rg, msg, file, level) = getLintMessageData lintMsg
+  case format of
+    "github" -> formatLintMessageGithub level rg msg file
+    _ -> formatLintMessageDefault level rg msg file
+
+formatLintMessageDefault :: String -> Region -> String -> String -> String
+formatLintMessageDefault level rg msg file = file ++ ": [" ++ level ++ "] " ++ (renderRegion rg) ++ ": " ++ msg
+
+formatLintMessageGithub :: String -> Region -> String -> String -> String
+formatLintMessageGithub level rg msg file = do
+  let (Region start _) = rg
+  let (LineColPos line col _) = start
+  "::" ++ map toLower level ++ " file=" ++ file ++ ",line=" ++ show (succ line) ++ ",col=" ++ show (succ col) ++ "::" ++ msg
 
 -- | Sort lint messages on file and then region
 sortLintMessages :: [LintMessage] -> [LintMessage]

--- a/src/GLuaFixer/LintSettings.hs
+++ b/src/GLuaFixer/LintSettings.hs
@@ -4,6 +4,7 @@ module GLuaFixer.LintSettings where
 import Data.Aeson
 import Control.Monad
 import GLua.AG.PrettyPrint
+import GLuaFixer.LintMessage
 
 data LintSettings =
     LintSettings
@@ -38,7 +39,7 @@ data LintSettings =
     , prettyprint_rejectInvalidCode  :: !Bool
     , prettyprint_indentation        :: !String
 
-    , log_format                     :: !String
+    , log_format                     :: !LogFormat
     } deriving (Show)
 
 defaultLintSettings :: LintSettings
@@ -75,7 +76,7 @@ defaultLintSettings =
     , prettyprint_rejectInvalidCode  = False
     , prettyprint_indentation        = "    "
 
-    , log_format                     = "standard"
+    , log_format                     = StandardLogFormat
   }
 
 instance FromJSON LintSettings where

--- a/src/GLuaFixer/LintSettings.hs
+++ b/src/GLuaFixer/LintSettings.hs
@@ -37,6 +37,8 @@ data LintSettings =
     , prettyprint_cStyle             :: !Bool
     , prettyprint_rejectInvalidCode  :: !Bool
     , prettyprint_indentation        :: !String
+
+    , log_format                     :: !String
     } deriving (Show)
 
 defaultLintSettings :: LintSettings
@@ -72,6 +74,8 @@ defaultLintSettings =
     , prettyprint_cStyle             = False
     , prettyprint_rejectInvalidCode  = False
     , prettyprint_indentation        = "    "
+
+    , log_format                     = "standard"
   }
 
 instance FromJSON LintSettings where
@@ -105,7 +109,8 @@ instance FromJSON LintSettings where
           v .:? "prettyprint_semicolons"         .!= prettyprint_semicolons defaultLintSettings         <*>
           v .:? "prettyprint_cStyle"             .!= prettyprint_cStyle defaultLintSettings             <*>
           v .:? "prettyprint_rejectInvalidCode"  .!= prettyprint_rejectInvalidCode defaultLintSettings  <*>
-          v .:? "prettyprint_indentation"        .!= prettyprint_indentation defaultLintSettings
+          v .:? "prettyprint_indentation"        .!= prettyprint_indentation defaultLintSettings        <*>
+          v .:? "log_format"                     .!= log_format defaultLintSettings
 
     parseJSON _          = mzero
 
@@ -152,4 +157,5 @@ instance ToJSON LintSettings where
         , "prettyprint_semicolons"         .= prettyprint_semicolons ls
         , "prettyprint_cStyle"             .= prettyprint_cStyle ls
         , "prettyprint_indentation"        .= prettyprint_indentation ls
+        , "log_format"                     .= log_format ls
         ]


### PR DESCRIPTION
This PR implements a basic format option to enable output that is readable by the GitHub actions parser 
(see https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-a-warning-message). 

This is particularly useful, when using glualint in a GitHub action workflow, to allow GitHub to parse the result and add annotations to the review.

The config option is backwards compatible and will by default still use the regular output format.

As this is my first time ever reading / writing Haskell, any feedback would be appreciated. I tried to keep it as simple as I could, but if there is anything, you would want to be changed / improved, let me know.

PS: Happy new year :rocket: :fireworks: 