### PR TITLE
Parenthesis Remover

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ Example `glualint.json` with the default options:
     "prettyprint_spaceAfterComma":      true,
     "prettyprint_semicolons":           false,
     "prettyprint_cStyle":               false,
-    "prettyprint_removeExtraParens":    true,
-    "prettyprint_removeAllExtraParens": false,
+    "prettyprint_removeRedundantParens": true,
+    "prettyprint_minimizeParens":       false,
     "prettyprint_rejectInvalidCode":    false,
     "prettyprint_indentation":          "    ",
 
@@ -116,8 +116,8 @@ These options affect the pretty printing functionality of `glualint`.
 - `prettyprint_indentation`: What to use for indentation. Any string is valid, but some amount of spaces or `"\t"` is recommended
 - `prettyprint_spaceBeforeComma`: Whether to place a space before every comma
 - `prettyprint_spaceAfterComma`: Whether to place a space after every comma
-- `prettyprint_removeExtraParens`: Whether to remove totally unnecessary parenthesis (e.g. `x = (1 + 2)`, `if ((1) + (2) == 3) then`)
-- `prettyprint_removeAllExtraParens`: Additionally removes parenthesis which are unnecessary due to operator precedence.
+- `prettyprint_removeRedundantParens`: Whether to remove unnecessary parentheses (e.g. `x = (1 + 2)`, `if ((1) + (2) == 3) then`)
+- `prettyprint_minimizeParens`: Removes parentheses which are unnecessary due to operator precedence (e.g. `(1 * 2) + 3`). This option also removes redundant parameters, regardless of whether `prettyprint_removeRedundantParens` is enabled.
 - `prettyprint_rejectInvalidCode`: Whether not to pretty print when the code is syntactically invalid
 
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ Example `glualint.json` with the default options:
     "prettyprint_spaceAfterComma":      true,
     "prettyprint_semicolons":           false,
     "prettyprint_cStyle":               false,
+    "prettyprint_removeExtraParens":    true,
+    "prettyprint_removeAllExtraParens": false,
     "prettyprint_rejectInvalidCode":    false,
     "prettyprint_indentation":          "    ",
 
@@ -114,6 +116,8 @@ These options affect the pretty printing functionality of `glualint`.
 - `prettyprint_indentation`: What to use for indentation. Any string is valid, but some amount of spaces or `"\t"` is recommended
 - `prettyprint_spaceBeforeComma`: Whether to place a space before every comma
 - `prettyprint_spaceAfterComma`: Whether to place a space after every comma
+- `prettyprint_removeExtraParens`: Whether to remove totally unnecessary parenthesis (e.g. `x = (1 + 2)`, `if ((1) + (2) == 3) then`)
+- `prettyprint_removeAllExtraParens`: Additionally removes parenthesis which are unnecessary due to operator precedence.
 - `prettyprint_rejectInvalidCode`: Whether not to pretty print when the code is syntactically invalid
 
 

--- a/src/GLua/AG/AST.ag
+++ b/src/GLua/AG/AST.ag
@@ -57,7 +57,7 @@ data Stat         -- a, b, c = ...
                   | AWhile   cond :: MExpr      body :: Block
                   -- repeat block until expr
                   | ARepeat  body :: Block      cond :: MExpr
-                  -- if exp r then block [elseif expr then block] [else block] end
+                  -- if expr then block [elseif expr then block] [else block] end
                   | AIf      cond :: MExpr      body :: Block     elifs :: ElseIfList els :: Else
                   -- for varname = expr, expr, expr? do block end, numeric for
                   | ANFor    var  :: MToken      val :: MExpr        to :: MExpr step :: MExpr body :: Block

--- a/src/GLua/AG/PrettyPrint.ag
+++ b/src/GLua/AG/PrettyPrint.ag
@@ -551,7 +551,17 @@ sem PrefixExp
                                                     MExpr _ (APrefixExpr _) -> True
                                                     _ -> False
                  loc.noparens =
+                    -- Parameters are redundant when the first expression below them is also
+                    -- parenthesized, when it's a top level expression or when the contents of the
+                    -- parentheses are a literal.
                     (removeRedundantParens @lhs.ppconf || minimizeParens @lhs.ppconf) && (@loc.containsParenthesizedExpr || (@lhs.parentOperatorPrecedence == TopLevelExpression || @expr.isLiteral) && length @suffixes.copy == 0) ||
+                    -- Parentheses can be minimized when there's no suffix (function call/index) and
+                    -- the parent operator's precedence is lower than the child expression's
+                    -- precedence OR they are equal and the parent operator is associative. There is
+                    -- no check for the child operator being associative (@expr.isAssociative),
+                    -- because evaluation order of the child itself does not change when the
+                    -- parentheses are removed. Only the order of evaluation between the parent
+                    -- operator and the child changes.
                     (minimizeParens @lhs.ppconf && length @suffixes.copy == 0 && (@lhs.parentOperatorPrecedence < @expr.precedence || @lhs.parentOperatorPrecedence == @expr.precedence && @lhs.parentOperatorAssociative))
                  lhs.potentiallyAmbiguousAsStatement = True
 

--- a/src/GLua/AG/PrettyPrint.ag
+++ b/src/GLua/AG/PrettyPrint.ag
@@ -216,8 +216,12 @@ attr MExpr Expr PrefixExp
     -- e.g. in `(1 + 2) * 3`, 1 and 2 get the precedence of the +, and 3 gets the precedence of the
     -- *.
     inh parentOperatorPrecedence :: OperatorLevel
+    -- Whether an expression is a literal string, number, table, bool nil or varargs. Defaults and
+    -- combines to False, because anything that contains a literal is no longer a literal.
+    syn isLiteral use {(\_ _ -> False)} {False} :: Bool
 
 attr ExprStuff BinOp
+    -- Operator precedence
     syn precedence use {min} {OperatorLevel8} :: OperatorLevel
 
 attr Declaration VarsList
@@ -522,8 +526,10 @@ sem FuncName
 
 sem PrefixExp
     | PFVar      lhs.pretty = tok @name <> @suffixes.pretty
+                 lhs.isLiteral = False
     | ExprVar    lhs.pretty = (if @loc.noparens then @expr.pretty else parens @lhs.ppconf NonEmpty @expr.pretty) <> @suffixes.pretty
                  lhs.precedence = if @loc.noparens then @expr.precedence else OperatorLevel8
+                 lhs.isLiteral = False
 
                  -- Whether this ExprVar contains another PrefixExp. In this case the parentheses
                  -- can be removed.
@@ -531,9 +537,8 @@ sem PrefixExp
                                                     MExpr _ (APrefixExpr _) -> True
                                                     _ -> False
                  loc.noparens =
-                    (removeRedundantParens @lhs.ppconf || minimizeParens @lhs.ppconf) && (@lhs.parentOperatorPrecedence == TopLevelExpression || @loc.containsParenthesizedExpr) ||
+                    (removeRedundantParens @lhs.ppconf || minimizeParens @lhs.ppconf) && (@loc.containsParenthesizedExpr || (@lhs.parentOperatorPrecedence == TopLevelExpression || @expr.isLiteral) && length @suffixes.copy == 0) ||
                     (minimizeParens @lhs.ppconf && length @suffixes.copy == 0 && @lhs.parentOperatorPrecedence < @expr.precedence)
-                 expr.parentOperatorPrecedence = TopLevelExpression
                  lhs.potentiallyAmbiguousAsStatement = True
 
 sem PFExprSuffix
@@ -549,11 +554,17 @@ sem MExpr
 
 sem Expr
     | ANil              lhs.pretty = zeroWidthText "nil"
+                        lhs.isLiteral = True
     | AFalse            lhs.pretty = zeroWidthText "false"
+                        lhs.isLiteral = True
     | ATrue             lhs.pretty = zeroWidthText "true"
+                        lhs.isLiteral = True
     | ANumber           lhs.pretty = zeroWidthText @num
+                        lhs.isLiteral = True
     | AString           lhs.pretty = tok @str
+                        lhs.isLiteral = True
     | AVarArg           lhs.pretty = zeroWidthText "..."
+                        lhs.isLiteral = True
     | AnonymousFunc     loc.isMultiline = @body.isMultiline || @body.statementCount > 1 || @body.statementCount == 1 && not @body.hasBreaking
                         loc.singleLinePretty = zeroWidthText "function" <> parens @lhs.ppconf @loc.emptyParams (printList tok (render @loc.comma) @pars) <-> @body.pretty <-> zeroWidthText "end"
                         loc.multilinePretty = zeroWidthText "function" <> parens @lhs.ppconf @loc.emptyParams (printList tok (render @loc.comma) @pars) $+$ @body.pretty $+$ indent @lhs.ppconf @lhs.indent (zeroWidthText "end")
@@ -566,6 +577,7 @@ sem Expr
     | ATableConstructor
                         lhs.pretty = if @fields.isMultiline then @loc.prettyMulti else @loc.prettySingle
                         lhs.isMultiline = not $ null $ @fields.copy
+                        lhs.isLiteral = True
                         loc.prettyMulti = zchr '{' $+$ indent @lhs.ppconf (@lhs.indent + 1) @fields.pretty $+$ indent @lhs.ppconf @lhs.indent (zchr '}')
                         loc.prettySingle = braces @lhs.ppconf @loc.emptyContents @fields.pretty
                         loc.emptyContents = toEmpty $ null @fields.copy

--- a/src/GLua/AG/PrettyPrint.ag
+++ b/src/GLua/AG/PrettyPrint.ag
@@ -216,6 +216,7 @@ attr MExpr Expr PrefixExp
     -- e.g. in `(1 + 2) * 3`, 1 and 2 get the precedence of the +, and 3 gets the precedence of the
     -- *.
     inh parentOperatorPrecedence :: OperatorLevel
+    inh parentOperatorAssociative :: Bool
     -- Whether an expression is a literal string, number, table, bool nil or varargs. Defaults and
     -- combines to False, because anything that contains a literal is no longer a literal.
     syn isLiteral use {(\_ _ -> False)} {False} :: Bool
@@ -223,6 +224,8 @@ attr MExpr Expr PrefixExp
 attr ExprStuff BinOp
     -- Operator precedence
     syn precedence use {min} {OperatorLevel8} :: OperatorLevel
+    -- Whether all operators in an expression are associative.
+    syn isAssociative use {&&} {False} :: Bool
 
 attr Declaration VarsList
     syn varPretty  use {<>} {empty}  :: Doc
@@ -324,6 +327,7 @@ sem MExprList
                  tl.isHead  = False
                  lhs.pos    = @hd.pos
                  hd.parentOperatorPrecedence = TopLevelExpression
+                 hd.parentOperatorAssociative = True
     | Nil        lhs.pretty = empty
                  lhs.pos    = emptyRg
 
@@ -365,6 +369,7 @@ sem MaybeMExpr
                 lhs.pretty = @just.pretty
                 lhs.isDefined = True
                 just.parentOperatorPrecedence = TopLevelExpression
+                just.parentOperatorAssociative = True
     | Nothing
                 lhs.pretty = empty
                 lhs.isDefined = False
@@ -373,6 +378,7 @@ sem Declaration
     | Tuple     lhs.varPretty = @x1.pretty
                 lhs.exprPretty = @x2.pretty
                 x1.parentOperatorPrecedence = TopLevelExpression
+                x1.parentOperatorAssociative = True
 
 sem VarsList
     | Cons      lhs.pretty = @loc.varPretty <-> if @loc.isDefined then zchr '=' <-> @loc.exprPretty else empty
@@ -393,6 +399,7 @@ sem ElseIf
                 x2.indent = @lhs.indent + 1
                 x2.statRegion = emptyRg
                 x1.parentOperatorPrecedence = TopLevelExpression
+                x1.parentOperatorAssociative = True
 
 sem MElseIf
     | MElseIf   lhs.pos = @pos
@@ -444,6 +451,7 @@ sem Stat
     | AFuncCall  lhs.pretty = @fn.pretty <> @loc.semicolon
                  loc.semicolon = if semicolons @lhs.ppconf || @lhs.potentiallyAmbiguousAsStatement then zchr ';' else empty
                  fn.parentOperatorPrecedence = TopLevelExpression
+                 fn.parentOperatorAssociative = True
     | ALabel     lhs.pretty = zeroWidthText "::" <> @loc.whitespace <> tok @lbl <> @loc.whitespace <> zeroWidthText "::"
                  loc.whitespace = if spaceAfterLabel @lhs.ppconf then zeroWidthText " " else empty
     | ABreak     lhs.pretty = zeroWidthText "break" <> @loc.semicolon
@@ -461,17 +469,20 @@ sem Stat
                  lhs.hasBreaking = False
     | AWhile     lhs.isMultiline = True
                  cond.parentOperatorPrecedence = TopLevelExpression
+                 cond.parentOperatorAssociative = True
                  lhs.pretty = zeroWidthText "while" <-> @cond.pretty <-> zeroWidthText "do" $+$ @body.pretty $+$ indent @lhs.ppconf @lhs.indent (zeroWidthText "end")
                  body.indent = @lhs.indent + 1
                  lhs.hasBreaking = False
     | ARepeat    lhs.pretty = zeroWidthText "repeat" $+$ @body.pretty $+$ indent @lhs.ppconf @lhs.indent (zeroWidthText "until" <-> @cond.pretty)
                  body.indent = @lhs.indent + 1
                  cond.parentOperatorPrecedence = TopLevelExpression
+                 cond.parentOperatorAssociative = True
                  lhs.hasBreaking = False
     | AIf        loc.isMultiline = @cond.isMultiline || @body.isMultiline || @body.statementCount > 1 || @body.statementCount == 1 && not @body.hasBreaking || @elifs.elsesExist || @els.elsesExist
                  loc.singleLinePretty = zeroWidthText "if" <-> @cond.pretty <-> zeroWidthText "then" <-> @body.pretty <-> zeroWidthText "end"
                  loc.multilinePretty  = zeroWidthText "if" <-> @cond.pretty <-> zeroWidthText "then" $+$ @body.pretty $+$ @elifs.pretty $+$ @els.pretty $+$ indent @lhs.ppconf @lhs.indent (zeroWidthText "end")
                  cond.parentOperatorPrecedence = TopLevelExpression
+                 cond.parentOperatorAssociative = True
                  body.indent = if @loc.isMultiline then @lhs.indent + 1 else 0
                  body.statRegion = @lhs.statRegion `upto` @elifs.pos `upto` @els.pos
                  lhs.pretty = if @loc.isMultiline then @loc.multilinePretty else @loc.singleLinePretty
@@ -483,8 +494,11 @@ sem Stat
                  lhs.pretty = zeroWidthText "for" <-> tok @var <-> zchr '=' <-> @val.pretty <> @loc.comma <> @to.pretty <> @loc.step <-> zeroWidthText "do" $+$ @body.pretty $+$ indent @lhs.ppconf @lhs.indent (zeroWidthText "end")
                  loc.comma = (if spaceBeforeComma @lhs.ppconf then zchr ' ' else empty) <> zchr ',' <> (if spaceAfterComma @lhs.ppconf then zchr ' ' else empty)
                  val.parentOperatorPrecedence = TopLevelExpression
+                 val.parentOperatorAssociative = True
                  to.parentOperatorPrecedence = TopLevelExpression
+                 to.parentOperatorAssociative = True
                  step.parentOperatorPrecedence = TopLevelExpression
+                 step.parentOperatorAssociative = True
                  body.indent = @lhs.indent + 1
                  lhs.hasBreaking = False
     | AGFor      lhs.isMultiline = True
@@ -538,7 +552,7 @@ sem PrefixExp
                                                     _ -> False
                  loc.noparens =
                     (removeRedundantParens @lhs.ppconf || minimizeParens @lhs.ppconf) && (@loc.containsParenthesizedExpr || (@lhs.parentOperatorPrecedence == TopLevelExpression || @expr.isLiteral) && length @suffixes.copy == 0) ||
-                    (minimizeParens @lhs.ppconf && length @suffixes.copy == 0 && @lhs.parentOperatorPrecedence < @expr.precedence)
+                    (minimizeParens @lhs.ppconf && length @suffixes.copy == 0 && (@lhs.parentOperatorPrecedence < @expr.precedence || @lhs.parentOperatorPrecedence == @expr.precedence && @lhs.parentOperatorAssociative))
                  lhs.potentiallyAmbiguousAsStatement = True
 
 sem PFExprSuffix
@@ -546,6 +560,7 @@ sem PFExprSuffix
     | MetaCall   lhs.pretty = zchr ':' <> tok @fn <> @args.pretty
     | ExprIndex  lhs.pretty = brackets @lhs.ppconf @index.pretty
                  index.parentOperatorPrecedence = TopLevelExpression
+                 index.parentOperatorAssociative = True
     | DotIndex   lhs.pretty = zchr '.' <> tok @index
 
 sem MExpr
@@ -588,6 +603,8 @@ sem Expr
                         lhs.precedence = min @op.precedence $ min @left.precedence @right.precedence
                         left.parentOperatorPrecedence = @op.precedence
                         right.parentOperatorPrecedence = @op.precedence
+                        left.parentOperatorAssociative = @op.isAssociative
+                        right.parentOperatorAssociative = @op.isAssociative
     | UnOpExpr          lhs.pretty = @op.pretty <> @right.pretty
                         lhs.precedence = min @right.precedence OperatorLevel7
                         right.parentOperatorPrecedence = OperatorLevel7
@@ -608,14 +625,18 @@ sem Field
                     lhs.isMultiline = True
                     lhs.canFitOnSameLine = False
                     key.parentOperatorPrecedence = TopLevelExpression
+                    key.parentOperatorAssociative = True
                     value.parentOperatorPrecedence = TopLevelExpression
+                    value.parentOperatorAssociative = True
     | NamedField    lhs.pretty = tok @key <-> zchr '=' <-> @value.pretty <> @sep.pretty
                     lhs.isMultiline = True
                     lhs.canFitOnSameLine = False
                     value.parentOperatorPrecedence = TopLevelExpression
+                    value.parentOperatorAssociative = True
     | UnnamedField  lhs.pretty = @value.pretty <> @sep.pretty
                     lhs.canFitOnSameLine = @sep.canFitOnSameLine && not @value.isMultiline
                     value.parentOperatorPrecedence = TopLevelExpression
+                    value.parentOperatorAssociative = True
 
 sem FieldSep
     | CommaSep      lhs.pretty = (if spaceBeforeComma @lhs.ppconf then zchr ' ' else empty) <> zchr ','
@@ -632,34 +653,49 @@ sem FieldSep
 sem BinOp
     | APlus         lhs.pretty = zeroWidthText "+"
                     lhs.precedence = OperatorLevel5
+                    lhs.isAssociative = True
     | BinMinus      lhs.pretty = zeroWidthText "-"
                     lhs.precedence = OperatorLevel5
+                    lhs.isAssociative = False
     | AMultiply     lhs.pretty = zeroWidthText "*"
                     lhs.precedence = OperatorLevel6
+                    lhs.isAssociative = True
     | ADivide       lhs.pretty = zeroWidthText "/"
                     lhs.precedence = OperatorLevel6
+                    lhs.isAssociative = False
     | AModulus      lhs.pretty = zeroWidthText "%"
                     lhs.precedence = OperatorLevel6
+                    lhs.isAssociative = False
     | APower        lhs.pretty = zeroWidthText "^"
                     lhs.precedence = OperatorLevel8
+                    lhs.isAssociative = False
     | AConcatenate  lhs.pretty = zeroWidthText ".."
                     lhs.precedence = OperatorLevel4
+                    lhs.isAssociative = True
     | ALT           lhs.pretty = zeroWidthText "<"
                     lhs.precedence = OperatorLevel3
+                    lhs.isAssociative = True
     | ALEQ          lhs.pretty = zeroWidthText "<="
                     lhs.precedence = OperatorLevel3
+                    lhs.isAssociative = True
     | AGT           lhs.pretty = zeroWidthText ">"
                     lhs.precedence = OperatorLevel3
+                    lhs.isAssociative = True
     | AGEQ          lhs.pretty = zeroWidthText ">="
                     lhs.precedence = OperatorLevel3
+                    lhs.isAssociative = True
     | AEq           lhs.pretty = zeroWidthText "=="
                     lhs.precedence = OperatorLevel3
+                    lhs.isAssociative = True
     | ANEq          lhs.pretty = zeroWidthText (if cStyle @lhs.ppconf then "!=" else "~=")
                     lhs.precedence = OperatorLevel3
+                    lhs.isAssociative = True
     | AAnd          lhs.pretty = zeroWidthText (if cStyle @lhs.ppconf then "&&" else "and")
                     lhs.precedence = OperatorLevel2
+                    lhs.isAssociative = True
     | AOr           lhs.pretty = zeroWidthText (if cStyle @lhs.ppconf then "||" else "or")
                     lhs.precedence = OperatorLevel1
+                    lhs.isAssociative = True
 
 sem UnOp
     | UnMinus  lhs.pretty = zeroWidthText "-"
@@ -675,7 +711,7 @@ pp_mstat :: MStat -> Int -> Doc
 pp_mstat p i = pretty_Syn_MStat (wrap_MStat (sem_MStat p) (Inh_MStat [] i False False defaultPPConfig))
 
 pp_prefixexp :: PrefixExp -> Doc
-pp_prefixexp p = pretty_Syn_PrefixExp (wrap_PrefixExp (sem_PrefixExp p) (Inh_PrefixExp [] 0 TopLevelExpression defaultPPConfig))
+pp_prefixexp p = pretty_Syn_PrefixExp (wrap_PrefixExp (sem_PrefixExp p) (Inh_PrefixExp [] 0 True TopLevelExpression defaultPPConfig))
 
 pp_pfexprsuffix :: PFExprSuffix -> Doc
 pp_pfexprsuffix p = pretty_Syn_PFExprSuffix (wrap_PFExprSuffix (sem_PFExprSuffix p) (Inh_PFExprSuffix [] 0 defaultPPConfig))
@@ -684,7 +720,7 @@ pp_field :: Field -> Doc
 pp_field p = pretty_Syn_Field (wrap_Field (sem_Field p) (Inh_Field [] 0 defaultPPConfig))
 
 pp_mexpr :: MExpr -> Doc
-pp_mexpr p = pretty_Syn_MExpr (wrap_MExpr (sem_MExpr p) (Inh_MExpr [] 0 TopLevelExpression defaultPPConfig))
+pp_mexpr p = pretty_Syn_MExpr (wrap_MExpr (sem_MExpr p) (Inh_MExpr [] 0 True TopLevelExpression defaultPPConfig))
 
 prettyprint :: AST -> String
 prettyprint p = render $ pretty_Syn_AST (wrap_AST (sem_AST p) (Inh_AST 0 defaultPPConfig))
@@ -708,13 +744,13 @@ renderFuncName     :: FuncName -> String
 renderFuncName p   = render $ pretty_Syn_FuncName (wrap_FuncName (sem_FuncName p) (Inh_FuncName [] 0 defaultPPConfig))
 
 renderPrefixExp    :: PrefixExp -> String
-renderPrefixExp p  = render $ pretty_Syn_PrefixExp (wrap_PrefixExp (sem_PrefixExp p) (Inh_PrefixExp [] 0 TopLevelExpression defaultPPConfig))
+renderPrefixExp p  = render $ pretty_Syn_PrefixExp (wrap_PrefixExp (sem_PrefixExp p) (Inh_PrefixExp [] 0 True TopLevelExpression defaultPPConfig))
 
 renderExpr         :: Expr -> String
-renderExpr p       = render $ pretty_Syn_Expr (wrap_Expr (sem_Expr p) (Inh_Expr [] 0 TopLevelExpression defaultPPConfig emptyRg))
+renderExpr p       = render $ pretty_Syn_Expr (wrap_Expr (sem_Expr p) (Inh_Expr [] 0 True TopLevelExpression defaultPPConfig emptyRg))
 
 renderMExpr         :: MExpr -> String
-renderMExpr p       = render $ pretty_Syn_MExpr (wrap_MExpr (sem_MExpr p) (Inh_MExpr [] 0 TopLevelExpression defaultPPConfig))
+renderMExpr p       = render $ pretty_Syn_MExpr (wrap_MExpr (sem_MExpr p) (Inh_MExpr [] 0 True TopLevelExpression defaultPPConfig))
 
 renderArgs         :: Args -> String
 renderArgs p       = render $ pretty_Syn_Args (wrap_Args (sem_Args p) (Inh_Args [] 0 defaultPPConfig))

--- a/src/GLua/AG/PrettyPrint.ag
+++ b/src/GLua/AG/PrettyPrint.ag
@@ -46,6 +46,8 @@ data PrettyPrintConfig = PPConfig {
     spaceAfterComma :: Bool,
     semicolons :: Bool,
     cStyle :: Bool,
+    removeExtraParens :: Bool,
+    removeAllExtraParens :: Bool,
     indentation :: String
 }
 
@@ -61,6 +63,8 @@ defaultPPConfig = PPConfig {
     spaceAfterComma = True,
     semicolons = False,
     cStyle = False,
+    removeExtraParens = True,
+    removeAllExtraParens = False,
     indentation = "    "
 }
 
@@ -182,15 +186,25 @@ infixl 6 <->
 a <-> b | a == empty = b
         | b == empty = a
         | otherwise  = a <> zchr ' ' <> b
+
+-- Always 10, so there is a default for precedence
+infixr 5 $$$
+($$$) :: Int -> Int -> Int
+a $$$ b = if a > b then 10 else 10
+
 }
 
 
 attr AllStuff
     syn pretty :: Doc
     inh indent :: Int
+    inh neighborPrecedence :: Int
     syn isMultiline use {||} {False} :: Bool -- whether code is printed over multiple lines
     inh ppconf :: PrettyPrintConfig
     syn copy :: self
+
+attr ExprStuff
+    syn precedence use {$$$} {10} :: Int
 
 attr Declaration VarsList
     syn varPretty  use {<>} {empty}  :: Doc
@@ -483,7 +497,12 @@ sem FuncName
 
 sem PrefixExp
     | PFVar      lhs.pretty = tok @name <> @suffixes.pretty
-    | ExprVar    lhs.pretty = parens @lhs.ppconf NonEmpty @expr.pretty <> @suffixes.pretty
+    | ExprVar    lhs.pretty = (if @loc.noparens then @expr.pretty else parens @lhs.ppconf NonEmpty @expr.pretty) <> @suffixes.pretty
+                 lhs.precedence = if @loc.noparens then @expr.precedence else 10
+                 loc.wraps = case @expr.copy of
+                                MExpr _ (APrefixExpr _) -> True
+                                _ -> False
+                 loc.noparens = removeExtraParens @lhs.ppconf && (@loc.wraps || (length @suffixes.copy == 0 && (@expr.precedence == 10 || @lhs.neighborPrecedence == 0 || removeAllExtraParens @lhs.ppconf && @lhs.neighborPrecedence < @expr.precedence)))
                  lhs.potentiallyAmbiguousAsStatement = True
 
 sem PFExprSuffix
@@ -509,6 +528,7 @@ sem Expr
                         loc.comma  = (if spaceBeforeComma @lhs.ppconf then zchr ' ' else empty) <> zchr ',' <> (if spaceAfterComma @lhs.ppconf then zchr ' ' else empty)
                         loc.emptyParams = toEmpty $ null @pars
                         body.indent = if @loc.isMultiline then @lhs.indent + 1 else 0
+                        body.neighborPrecedence = 0
                         lhs.pretty = if @loc.isMultiline then @loc.multilinePretty else @loc.singleLinePretty
     | APrefixExpr       lhs.pretty = @pexpr.pretty
                         lhs.wouldBeAmbiguousIfNextStatementIsExprVar = True
@@ -519,18 +539,43 @@ sem Expr
                         loc.prettySingle = braces @lhs.ppconf @loc.emptyContents @fields.pretty
                         loc.emptyContents = toEmpty $ null @fields.copy
                         fields.indent = @lhs.indent + (if @fields.isMultiline then 1 else 0)
+                        fields.neighborPrecedence = 0
     | BinOpExpr         lhs.pretty = @left.pretty <-> @op.pretty <-> @right.pretty
+                        loc.precedence = case @op.copy of
+                                            AOr -> 1
+                                            AAnd -> 2
+                                            ALT -> 3
+                                            AGT -> 3
+                                            ALEQ -> 3
+                                            AGEQ -> 3
+                                            ANEq -> 3
+                                            AEq -> 3
+                                            AConcatenate -> 4
+                                            APlus -> 5
+                                            BinMinus -> 5
+                                            AMultiply -> 6
+                                            ADivide -> 6
+                                            AModulus -> 6
+                                            APower -> 8
+                        -- Note: the AST doesn't always represent precedence correctly in unparenthesized unary/binary expressions
+                        lhs.precedence = min @loc.precedence $ min @left.precedence @right.precedence
+                        left.neighborPrecedence = @loc.precedence
+                        right.neighborPrecedence = @loc.precedence
     | UnOpExpr          lhs.pretty = @op.pretty <> @right.pretty
+                        lhs.precedence = min @right.precedence 7
+                        right.neighborPrecedence = 7
 
 sem Args
     | ListArgs  lhs.pretty = parens @lhs.ppconf @loc.emptyParams @args.pretty
                 loc.emptyParams = toEmpty $ null @args.copy
+                args.neighborPrecedence = 0
                 args.isHead = True
     | TableArg  lhs.pretty = if @arg.isMultiline then @loc.prettyMulti else @loc.prettySingle
                 loc.prettyMulti = zchr '{' $+$ indent @lhs.ppconf (@lhs.indent + 1) @arg.pretty $+$ indent @lhs.ppconf @lhs.indent (zchr '}')
                 loc.prettySingle = braces @lhs.ppconf @loc.emptyContents @arg.pretty
                 loc.emptyContents = toEmpty $ null @arg.copy
                 arg.indent = @lhs.indent + (if @arg.isMultiline then 1 else 0)
+                arg.neighborPrecedence = 0
     | StringArg lhs.pretty = tok @arg
 
 sem Field
@@ -580,57 +625,57 @@ sem UnOp
 {
 
 pp_block :: Block -> Int -> Doc
-pp_block p i = pretty_Syn_Block (wrap_Block (sem_Block p) (Inh_Block [] i defaultPPConfig emptyRg))
+pp_block p i = pretty_Syn_Block (wrap_Block (sem_Block p) (Inh_Block [] i 0 defaultPPConfig emptyRg))
 
 pp_mstat :: MStat -> Int -> Doc
-pp_mstat p i = pretty_Syn_MStat (wrap_MStat (sem_MStat p) (Inh_MStat [] i False False defaultPPConfig))
+pp_mstat p i = pretty_Syn_MStat (wrap_MStat (sem_MStat p) (Inh_MStat [] i False 0 False defaultPPConfig))
 
 pp_prefixexp :: PrefixExp -> Doc
-pp_prefixexp p = pretty_Syn_PrefixExp (wrap_PrefixExp (sem_PrefixExp p) (Inh_PrefixExp [] 0 defaultPPConfig))
+pp_prefixexp p = pretty_Syn_PrefixExp (wrap_PrefixExp (sem_PrefixExp p) (Inh_PrefixExp [] 0 0 defaultPPConfig))
 
 pp_pfexprsuffix :: PFExprSuffix -> Doc
-pp_pfexprsuffix p = pretty_Syn_PFExprSuffix (wrap_PFExprSuffix (sem_PFExprSuffix p) (Inh_PFExprSuffix [] 0 defaultPPConfig))
+pp_pfexprsuffix p = pretty_Syn_PFExprSuffix (wrap_PFExprSuffix (sem_PFExprSuffix p) (Inh_PFExprSuffix [] 0 0 defaultPPConfig))
 
 pp_field :: Field -> Doc
-pp_field p = pretty_Syn_Field (wrap_Field (sem_Field p) (Inh_Field [] 0 defaultPPConfig))
+pp_field p = pretty_Syn_Field (wrap_Field (sem_Field p) (Inh_Field [] 0 0 defaultPPConfig))
 
 pp_mexpr :: MExpr -> Doc
-pp_mexpr p = pretty_Syn_MExpr (wrap_MExpr (sem_MExpr p) (Inh_MExpr [] 0 defaultPPConfig))
+pp_mexpr p = pretty_Syn_MExpr (wrap_MExpr (sem_MExpr p) (Inh_MExpr [] 0 0 defaultPPConfig))
 
 prettyprint :: AST -> String
-prettyprint p = render $ pretty_Syn_AST (wrap_AST (sem_AST p) (Inh_AST 0 defaultPPConfig))
+prettyprint p = render $ pretty_Syn_AST (wrap_AST (sem_AST p) (Inh_AST 0 0 defaultPPConfig))
 
 prettyprintConf :: PrettyPrintConfig -> AST -> String
-prettyprintConf conf p = render $ pretty_Syn_AST (wrap_AST (sem_AST p) (Inh_AST 0 conf))
+prettyprintConf conf p = render $ pretty_Syn_AST (wrap_AST (sem_AST p) (Inh_AST 0 0 conf))
 
 renderBlock        :: Block -> String
-renderBlock p      = render $ pretty_Syn_Block (wrap_Block (sem_Block p) (Inh_Block [] 0 defaultPPConfig emptyRg))
+renderBlock p      = render $ pretty_Syn_Block (wrap_Block (sem_Block p) (Inh_Block [] 0 0 defaultPPConfig emptyRg))
 
 renderStat         :: Stat -> String
-renderStat p       = render $ pretty_Syn_Stat (wrap_Stat (sem_Stat p) (Inh_Stat [] 0 False False defaultPPConfig emptyRg))
+renderStat p       = render $ pretty_Syn_Stat (wrap_Stat (sem_Stat p) (Inh_Stat [] 0 False 0 False defaultPPConfig emptyRg))
 
 renderMStat         :: MStat -> String
-renderMStat p       = render $ pretty_Syn_MStat (wrap_MStat (sem_MStat p) (Inh_MStat [] 0 False False defaultPPConfig))
+renderMStat p       = render $ pretty_Syn_MStat (wrap_MStat (sem_MStat p) (Inh_MStat [] 0 False 0 False defaultPPConfig))
 
 renderAReturn      :: AReturn -> String
-renderAReturn p    = render $ pretty_Syn_AReturn (wrap_AReturn (sem_AReturn p) (Inh_AReturn [] 0 defaultPPConfig))
+renderAReturn p    = render $ pretty_Syn_AReturn (wrap_AReturn (sem_AReturn p) (Inh_AReturn [] 0 0 defaultPPConfig))
 
 renderFuncName     :: FuncName -> String
-renderFuncName p   = render $ pretty_Syn_FuncName (wrap_FuncName (sem_FuncName p) (Inh_FuncName [] 0 defaultPPConfig))
+renderFuncName p   = render $ pretty_Syn_FuncName (wrap_FuncName (sem_FuncName p) (Inh_FuncName [] 0 0 defaultPPConfig))
 
 renderPrefixExp    :: PrefixExp -> String
-renderPrefixExp p  = render $ pretty_Syn_PrefixExp (wrap_PrefixExp (sem_PrefixExp p) (Inh_PrefixExp [] 0 defaultPPConfig))
+renderPrefixExp p  = render $ pretty_Syn_PrefixExp (wrap_PrefixExp (sem_PrefixExp p) (Inh_PrefixExp [] 0 0 defaultPPConfig))
 
 renderExpr         :: Expr -> String
-renderExpr p       = render $ pretty_Syn_Expr (wrap_Expr (sem_Expr p) (Inh_Expr [] 0 defaultPPConfig emptyRg))
+renderExpr p       = render $ pretty_Syn_Expr (wrap_Expr (sem_Expr p) (Inh_Expr [] 0 0 defaultPPConfig emptyRg))
 
 renderMExpr         :: MExpr -> String
-renderMExpr p       = render $ pretty_Syn_MExpr (wrap_MExpr (sem_MExpr p) (Inh_MExpr [] 0 defaultPPConfig))
+renderMExpr p       = render $ pretty_Syn_MExpr (wrap_MExpr (sem_MExpr p) (Inh_MExpr [] 0 0 defaultPPConfig))
 
 renderArgs         :: Args -> String
-renderArgs p       = render $ pretty_Syn_Args (wrap_Args (sem_Args p) (Inh_Args [] 0 defaultPPConfig))
+renderArgs p       = render $ pretty_Syn_Args (wrap_Args (sem_Args p) (Inh_Args [] 0 0 defaultPPConfig))
 
 renderField        :: Field -> String
-renderField p      = render $ pretty_Syn_Field (wrap_Field (sem_Field p) (Inh_Field [] 0 defaultPPConfig))
+renderField p      = render $ pretty_Syn_Field (wrap_Field (sem_Field p) (Inh_Field [] 0 0 defaultPPConfig))
 
 }

--- a/src/GLua/AG/PrettyPrint.ag
+++ b/src/GLua/AG/PrettyPrint.ag
@@ -46,8 +46,8 @@ data PrettyPrintConfig = PPConfig {
     spaceAfterComma :: Bool,
     semicolons :: Bool,
     cStyle :: Bool,
-    removeExtraParens :: Bool,
-    removeAllExtraParens :: Bool,
+    removeRedundantParens :: Bool,
+    minimizeParens :: Bool,
     indentation :: String
 }
 
@@ -63,8 +63,8 @@ defaultPPConfig = PPConfig {
     spaceAfterComma = True,
     semicolons = False,
     cStyle = False,
-    removeExtraParens = True,
-    removeAllExtraParens = False,
+    removeRedundantParens = True,
+    minimizeParens = False,
     indentation = "    "
 }
 
@@ -187,24 +187,38 @@ a <-> b | a == empty = b
         | b == empty = a
         | otherwise  = a <> zchr ' ' <> b
 
--- Always 10, so there is a default for precedence
-infixr 5 $$$
-($$$) :: Int -> Int -> Int
-a $$$ b = if a > b then 10 else 10
-
+-- Operator levels, where level 1 is the lowest level, and level 8 is the highest one
+-- See http://www.lua.org/manual/5.2/manual.html#3.4.7
+data OperatorLevel
+    -- At the top level, there is no assigned operator level yet. This serves as a bottom value.
+    = TopLevelExpression
+    | OperatorLevel1
+    | OperatorLevel2
+    | OperatorLevel3
+    | OperatorLevel4
+    | OperatorLevel5
+    | OperatorLevel6
+    | OperatorLevel7
+    | OperatorLevel8
+    deriving (Eq, Ord)
 }
 
 
 attr AllStuff
     syn pretty :: Doc
     inh indent :: Int
-    inh neighborPrecedence :: Int
     syn isMultiline use {||} {False} :: Bool -- whether code is printed over multiple lines
     inh ppconf :: PrettyPrintConfig
     syn copy :: self
 
-attr ExprStuff
-    syn precedence use {$$$} {10} :: Int
+attr MExpr Expr PrefixExp
+    -- The precedence of the nearest operator higher up in an expression tree.
+    -- e.g. in `(1 + 2) * 3`, 1 and 2 get the precedence of the +, and 3 gets the precedence of the
+    -- *.
+    inh parentOperatorPrecedence :: OperatorLevel
+
+attr ExprStuff BinOp
+    syn precedence use {min} {OperatorLevel8} :: OperatorLevel
 
 attr Declaration VarsList
     syn varPretty  use {<>} {empty}  :: Doc
@@ -305,6 +319,7 @@ sem MExprList
                  loc.comma  = (if spaceBeforeComma @lhs.ppconf then zchr ' ' else empty) <> zchr ',' <> (if spaceAfterComma @lhs.ppconf then zchr ' ' else empty)
                  tl.isHead  = False
                  lhs.pos    = @hd.pos
+                 hd.parentOperatorPrecedence = TopLevelExpression
     | Nil        lhs.pretty = empty
                  lhs.pos    = emptyRg
 
@@ -345,6 +360,7 @@ sem MaybeMExpr
     | Just
                 lhs.pretty = @just.pretty
                 lhs.isDefined = True
+                just.parentOperatorPrecedence = TopLevelExpression
     | Nothing
                 lhs.pretty = empty
                 lhs.isDefined = False
@@ -352,6 +368,7 @@ sem MaybeMExpr
 sem Declaration
     | Tuple     lhs.varPretty = @x1.pretty
                 lhs.exprPretty = @x2.pretty
+                x1.parentOperatorPrecedence = TopLevelExpression
 
 sem VarsList
     | Cons      lhs.pretty = @loc.varPretty <-> if @loc.isDefined then zchr '=' <-> @loc.exprPretty else empty
@@ -371,6 +388,7 @@ sem ElseIf
     | Tuple     lhs.pretty = zeroWidthText "elseif" <-> @x1.pretty <-> zeroWidthText "then" $+$ @x2.pretty
                 x2.indent = @lhs.indent + 1
                 x2.statRegion = emptyRg
+                x1.parentOperatorPrecedence = TopLevelExpression
 
 sem MElseIf
     | MElseIf   lhs.pos = @pos
@@ -421,6 +439,7 @@ sem Stat
                  vars.isHead = True
     | AFuncCall  lhs.pretty = @fn.pretty <> @loc.semicolon
                  loc.semicolon = if semicolons @lhs.ppconf || @lhs.potentiallyAmbiguousAsStatement then zchr ';' else empty
+                 fn.parentOperatorPrecedence = TopLevelExpression
     | ALabel     lhs.pretty = zeroWidthText "::" <> @loc.whitespace <> tok @lbl <> @loc.whitespace <> zeroWidthText "::"
                  loc.whitespace = if spaceAfterLabel @lhs.ppconf then zeroWidthText " " else empty
     | ABreak     lhs.pretty = zeroWidthText "break" <> @loc.semicolon
@@ -437,15 +456,18 @@ sem Stat
                  body.indent = @lhs.indent + 1
                  lhs.hasBreaking = False
     | AWhile     lhs.isMultiline = True
+                 cond.parentOperatorPrecedence = TopLevelExpression
                  lhs.pretty = zeroWidthText "while" <-> @cond.pretty <-> zeroWidthText "do" $+$ @body.pretty $+$ indent @lhs.ppconf @lhs.indent (zeroWidthText "end")
                  body.indent = @lhs.indent + 1
                  lhs.hasBreaking = False
     | ARepeat    lhs.pretty = zeroWidthText "repeat" $+$ @body.pretty $+$ indent @lhs.ppconf @lhs.indent (zeroWidthText "until" <-> @cond.pretty)
                  body.indent = @lhs.indent + 1
+                 cond.parentOperatorPrecedence = TopLevelExpression
                  lhs.hasBreaking = False
     | AIf        loc.isMultiline = @cond.isMultiline || @body.isMultiline || @body.statementCount > 1 || @body.statementCount == 1 && not @body.hasBreaking || @elifs.elsesExist || @els.elsesExist
                  loc.singleLinePretty = zeroWidthText "if" <-> @cond.pretty <-> zeroWidthText "then" <-> @body.pretty <-> zeroWidthText "end"
                  loc.multilinePretty  = zeroWidthText "if" <-> @cond.pretty <-> zeroWidthText "then" $+$ @body.pretty $+$ @elifs.pretty $+$ @els.pretty $+$ indent @lhs.ppconf @lhs.indent (zeroWidthText "end")
+                 cond.parentOperatorPrecedence = TopLevelExpression
                  body.indent = if @loc.isMultiline then @lhs.indent + 1 else 0
                  body.statRegion = @lhs.statRegion `upto` @elifs.pos `upto` @els.pos
                  lhs.pretty = if @loc.isMultiline then @loc.multilinePretty else @loc.singleLinePretty
@@ -456,6 +478,9 @@ sem Stat
                                 _ -> @loc.comma <> @step.pretty
                  lhs.pretty = zeroWidthText "for" <-> tok @var <-> zchr '=' <-> @val.pretty <> @loc.comma <> @to.pretty <> @loc.step <-> zeroWidthText "do" $+$ @body.pretty $+$ indent @lhs.ppconf @lhs.indent (zeroWidthText "end")
                  loc.comma = (if spaceBeforeComma @lhs.ppconf then zchr ' ' else empty) <> zchr ',' <> (if spaceAfterComma @lhs.ppconf then zchr ' ' else empty)
+                 val.parentOperatorPrecedence = TopLevelExpression
+                 to.parentOperatorPrecedence = TopLevelExpression
+                 step.parentOperatorPrecedence = TopLevelExpression
                  body.indent = @lhs.indent + 1
                  lhs.hasBreaking = False
     | AGFor      lhs.isMultiline = True
@@ -498,17 +523,24 @@ sem FuncName
 sem PrefixExp
     | PFVar      lhs.pretty = tok @name <> @suffixes.pretty
     | ExprVar    lhs.pretty = (if @loc.noparens then @expr.pretty else parens @lhs.ppconf NonEmpty @expr.pretty) <> @suffixes.pretty
-                 lhs.precedence = if @loc.noparens then @expr.precedence else 10
-                 loc.wraps = case @expr.copy of
-                                MExpr _ (APrefixExpr _) -> True
-                                _ -> False
-                 loc.noparens = removeExtraParens @lhs.ppconf && (@loc.wraps || (length @suffixes.copy == 0 && (@expr.precedence == 10 || @lhs.neighborPrecedence == 0 || removeAllExtraParens @lhs.ppconf && @lhs.neighborPrecedence < @expr.precedence)))
+                 lhs.precedence = if @loc.noparens then @expr.precedence else OperatorLevel8
+
+                 -- Whether this ExprVar contains another PrefixExp. In this case the parentheses
+                 -- can be removed.
+                 loc.containsParenthesizedExpr = case @expr.copy of
+                                                    MExpr _ (APrefixExpr _) -> True
+                                                    _ -> False
+                 loc.noparens =
+                    (removeRedundantParens @lhs.ppconf || minimizeParens @lhs.ppconf) && (@lhs.parentOperatorPrecedence == TopLevelExpression || @loc.containsParenthesizedExpr) ||
+                    (minimizeParens @lhs.ppconf && length @suffixes.copy == 0 && @lhs.parentOperatorPrecedence < @expr.precedence)
+                 expr.parentOperatorPrecedence = TopLevelExpression
                  lhs.potentiallyAmbiguousAsStatement = True
 
 sem PFExprSuffix
     | Call       lhs.pretty = @args.pretty
     | MetaCall   lhs.pretty = zchr ':' <> tok @fn <> @args.pretty
     | ExprIndex  lhs.pretty = brackets @lhs.ppconf @index.pretty
+                 index.parentOperatorPrecedence = TopLevelExpression
     | DotIndex   lhs.pretty = zchr '.' <> tok @index
 
 sem MExpr
@@ -528,7 +560,6 @@ sem Expr
                         loc.comma  = (if spaceBeforeComma @lhs.ppconf then zchr ' ' else empty) <> zchr ',' <> (if spaceAfterComma @lhs.ppconf then zchr ' ' else empty)
                         loc.emptyParams = toEmpty $ null @pars
                         body.indent = if @loc.isMultiline then @lhs.indent + 1 else 0
-                        body.neighborPrecedence = 0
                         lhs.pretty = if @loc.isMultiline then @loc.multilinePretty else @loc.singleLinePretty
     | APrefixExpr       lhs.pretty = @pexpr.pretty
                         lhs.wouldBeAmbiguousIfNextStatementIsExprVar = True
@@ -539,54 +570,40 @@ sem Expr
                         loc.prettySingle = braces @lhs.ppconf @loc.emptyContents @fields.pretty
                         loc.emptyContents = toEmpty $ null @fields.copy
                         fields.indent = @lhs.indent + (if @fields.isMultiline then 1 else 0)
-                        fields.neighborPrecedence = 0
     | BinOpExpr         lhs.pretty = @left.pretty <-> @op.pretty <-> @right.pretty
-                        loc.precedence = case @op.copy of
-                                            AOr -> 1
-                                            AAnd -> 2
-                                            ALT -> 3
-                                            AGT -> 3
-                                            ALEQ -> 3
-                                            AGEQ -> 3
-                                            ANEq -> 3
-                                            AEq -> 3
-                                            AConcatenate -> 4
-                                            APlus -> 5
-                                            BinMinus -> 5
-                                            AMultiply -> 6
-                                            ADivide -> 6
-                                            AModulus -> 6
-                                            APower -> 8
-                        -- Note: the AST doesn't always represent precedence correctly in unparenthesized unary/binary expressions
-                        lhs.precedence = min @loc.precedence $ min @left.precedence @right.precedence
-                        left.neighborPrecedence = @loc.precedence
-                        right.neighborPrecedence = @loc.precedence
+                        -- Note: the AST doesn't always represent precedence correctly in
+                        -- unparenthesized unary/binary expressions
+                        lhs.precedence = min @op.precedence $ min @left.precedence @right.precedence
+                        left.parentOperatorPrecedence = @op.precedence
+                        right.parentOperatorPrecedence = @op.precedence
     | UnOpExpr          lhs.pretty = @op.pretty <> @right.pretty
-                        lhs.precedence = min @right.precedence 7
-                        right.neighborPrecedence = 7
+                        lhs.precedence = min @right.precedence OperatorLevel7
+                        right.parentOperatorPrecedence = OperatorLevel7
 
 sem Args
     | ListArgs  lhs.pretty = parens @lhs.ppconf @loc.emptyParams @args.pretty
                 loc.emptyParams = toEmpty $ null @args.copy
-                args.neighborPrecedence = 0
                 args.isHead = True
     | TableArg  lhs.pretty = if @arg.isMultiline then @loc.prettyMulti else @loc.prettySingle
                 loc.prettyMulti = zchr '{' $+$ indent @lhs.ppconf (@lhs.indent + 1) @arg.pretty $+$ indent @lhs.ppconf @lhs.indent (zchr '}')
                 loc.prettySingle = braces @lhs.ppconf @loc.emptyContents @arg.pretty
                 loc.emptyContents = toEmpty $ null @arg.copy
                 arg.indent = @lhs.indent + (if @arg.isMultiline then 1 else 0)
-                arg.neighborPrecedence = 0
     | StringArg lhs.pretty = tok @arg
 
 sem Field
     | ExprField     lhs.pretty = brackets @lhs.ppconf @key.pretty <-> zchr '=' <-> @value.pretty <> @sep.pretty
                     lhs.isMultiline = True
                     lhs.canFitOnSameLine = False
+                    key.parentOperatorPrecedence = TopLevelExpression
+                    value.parentOperatorPrecedence = TopLevelExpression
     | NamedField    lhs.pretty = tok @key <-> zchr '=' <-> @value.pretty <> @sep.pretty
                     lhs.isMultiline = True
                     lhs.canFitOnSameLine = False
+                    value.parentOperatorPrecedence = TopLevelExpression
     | UnnamedField  lhs.pretty = @value.pretty <> @sep.pretty
                     lhs.canFitOnSameLine = @sep.canFitOnSameLine && not @value.isMultiline
+                    value.parentOperatorPrecedence = TopLevelExpression
 
 sem FieldSep
     | CommaSep      lhs.pretty = (if spaceBeforeComma @lhs.ppconf then zchr ' ' else empty) <> zchr ','
@@ -602,20 +619,35 @@ sem FieldSep
 
 sem BinOp
     | APlus         lhs.pretty = zeroWidthText "+"
+                    lhs.precedence = OperatorLevel5
     | BinMinus      lhs.pretty = zeroWidthText "-"
+                    lhs.precedence = OperatorLevel5
     | AMultiply     lhs.pretty = zeroWidthText "*"
+                    lhs.precedence = OperatorLevel6
     | ADivide       lhs.pretty = zeroWidthText "/"
+                    lhs.precedence = OperatorLevel6
     | AModulus      lhs.pretty = zeroWidthText "%"
+                    lhs.precedence = OperatorLevel6
     | APower        lhs.pretty = zeroWidthText "^"
+                    lhs.precedence = OperatorLevel8
     | AConcatenate  lhs.pretty = zeroWidthText ".."
+                    lhs.precedence = OperatorLevel4
     | ALT           lhs.pretty = zeroWidthText "<"
+                    lhs.precedence = OperatorLevel3
     | ALEQ          lhs.pretty = zeroWidthText "<="
+                    lhs.precedence = OperatorLevel3
     | AGT           lhs.pretty = zeroWidthText ">"
+                    lhs.precedence = OperatorLevel3
     | AGEQ          lhs.pretty = zeroWidthText ">="
+                    lhs.precedence = OperatorLevel3
     | AEq           lhs.pretty = zeroWidthText "=="
+                    lhs.precedence = OperatorLevel3
     | ANEq          lhs.pretty = zeroWidthText (if cStyle @lhs.ppconf then "!=" else "~=")
+                    lhs.precedence = OperatorLevel3
     | AAnd          lhs.pretty = zeroWidthText (if cStyle @lhs.ppconf then "&&" else "and")
+                    lhs.precedence = OperatorLevel2
     | AOr           lhs.pretty = zeroWidthText (if cStyle @lhs.ppconf then "||" else "or")
+                    lhs.precedence = OperatorLevel1
 
 sem UnOp
     | UnMinus  lhs.pretty = zeroWidthText "-"
@@ -625,57 +657,57 @@ sem UnOp
 {
 
 pp_block :: Block -> Int -> Doc
-pp_block p i = pretty_Syn_Block (wrap_Block (sem_Block p) (Inh_Block [] i 0 defaultPPConfig emptyRg))
+pp_block p i = pretty_Syn_Block (wrap_Block (sem_Block p) (Inh_Block [] i defaultPPConfig emptyRg))
 
 pp_mstat :: MStat -> Int -> Doc
-pp_mstat p i = pretty_Syn_MStat (wrap_MStat (sem_MStat p) (Inh_MStat [] i False 0 False defaultPPConfig))
+pp_mstat p i = pretty_Syn_MStat (wrap_MStat (sem_MStat p) (Inh_MStat [] i False False defaultPPConfig))
 
 pp_prefixexp :: PrefixExp -> Doc
-pp_prefixexp p = pretty_Syn_PrefixExp (wrap_PrefixExp (sem_PrefixExp p) (Inh_PrefixExp [] 0 0 defaultPPConfig))
+pp_prefixexp p = pretty_Syn_PrefixExp (wrap_PrefixExp (sem_PrefixExp p) (Inh_PrefixExp [] 0 TopLevelExpression defaultPPConfig))
 
 pp_pfexprsuffix :: PFExprSuffix -> Doc
-pp_pfexprsuffix p = pretty_Syn_PFExprSuffix (wrap_PFExprSuffix (sem_PFExprSuffix p) (Inh_PFExprSuffix [] 0 0 defaultPPConfig))
+pp_pfexprsuffix p = pretty_Syn_PFExprSuffix (wrap_PFExprSuffix (sem_PFExprSuffix p) (Inh_PFExprSuffix [] 0 defaultPPConfig))
 
 pp_field :: Field -> Doc
-pp_field p = pretty_Syn_Field (wrap_Field (sem_Field p) (Inh_Field [] 0 0 defaultPPConfig))
+pp_field p = pretty_Syn_Field (wrap_Field (sem_Field p) (Inh_Field [] 0 defaultPPConfig))
 
 pp_mexpr :: MExpr -> Doc
-pp_mexpr p = pretty_Syn_MExpr (wrap_MExpr (sem_MExpr p) (Inh_MExpr [] 0 0 defaultPPConfig))
+pp_mexpr p = pretty_Syn_MExpr (wrap_MExpr (sem_MExpr p) (Inh_MExpr [] 0 TopLevelExpression defaultPPConfig))
 
 prettyprint :: AST -> String
-prettyprint p = render $ pretty_Syn_AST (wrap_AST (sem_AST p) (Inh_AST 0 0 defaultPPConfig))
+prettyprint p = render $ pretty_Syn_AST (wrap_AST (sem_AST p) (Inh_AST 0 defaultPPConfig))
 
 prettyprintConf :: PrettyPrintConfig -> AST -> String
-prettyprintConf conf p = render $ pretty_Syn_AST (wrap_AST (sem_AST p) (Inh_AST 0 0 conf))
+prettyprintConf conf p = render $ pretty_Syn_AST (wrap_AST (sem_AST p) (Inh_AST 0 conf))
 
 renderBlock        :: Block -> String
-renderBlock p      = render $ pretty_Syn_Block (wrap_Block (sem_Block p) (Inh_Block [] 0 0 defaultPPConfig emptyRg))
+renderBlock p      = render $ pretty_Syn_Block (wrap_Block (sem_Block p) (Inh_Block [] 0 defaultPPConfig emptyRg))
 
 renderStat         :: Stat -> String
-renderStat p       = render $ pretty_Syn_Stat (wrap_Stat (sem_Stat p) (Inh_Stat [] 0 False 0 False defaultPPConfig emptyRg))
+renderStat p       = render $ pretty_Syn_Stat (wrap_Stat (sem_Stat p) (Inh_Stat [] 0 False False defaultPPConfig emptyRg))
 
 renderMStat         :: MStat -> String
-renderMStat p       = render $ pretty_Syn_MStat (wrap_MStat (sem_MStat p) (Inh_MStat [] 0 False 0 False defaultPPConfig))
+renderMStat p       = render $ pretty_Syn_MStat (wrap_MStat (sem_MStat p) (Inh_MStat [] 0 False False defaultPPConfig))
 
 renderAReturn      :: AReturn -> String
-renderAReturn p    = render $ pretty_Syn_AReturn (wrap_AReturn (sem_AReturn p) (Inh_AReturn [] 0 0 defaultPPConfig))
+renderAReturn p    = render $ pretty_Syn_AReturn (wrap_AReturn (sem_AReturn p) (Inh_AReturn [] 0 defaultPPConfig))
 
 renderFuncName     :: FuncName -> String
-renderFuncName p   = render $ pretty_Syn_FuncName (wrap_FuncName (sem_FuncName p) (Inh_FuncName [] 0 0 defaultPPConfig))
+renderFuncName p   = render $ pretty_Syn_FuncName (wrap_FuncName (sem_FuncName p) (Inh_FuncName [] 0 defaultPPConfig))
 
 renderPrefixExp    :: PrefixExp -> String
-renderPrefixExp p  = render $ pretty_Syn_PrefixExp (wrap_PrefixExp (sem_PrefixExp p) (Inh_PrefixExp [] 0 0 defaultPPConfig))
+renderPrefixExp p  = render $ pretty_Syn_PrefixExp (wrap_PrefixExp (sem_PrefixExp p) (Inh_PrefixExp [] 0 TopLevelExpression defaultPPConfig))
 
 renderExpr         :: Expr -> String
-renderExpr p       = render $ pretty_Syn_Expr (wrap_Expr (sem_Expr p) (Inh_Expr [] 0 0 defaultPPConfig emptyRg))
+renderExpr p       = render $ pretty_Syn_Expr (wrap_Expr (sem_Expr p) (Inh_Expr [] 0 TopLevelExpression defaultPPConfig emptyRg))
 
 renderMExpr         :: MExpr -> String
-renderMExpr p       = render $ pretty_Syn_MExpr (wrap_MExpr (sem_MExpr p) (Inh_MExpr [] 0 0 defaultPPConfig))
+renderMExpr p       = render $ pretty_Syn_MExpr (wrap_MExpr (sem_MExpr p) (Inh_MExpr [] 0 TopLevelExpression defaultPPConfig))
 
 renderArgs         :: Args -> String
-renderArgs p       = render $ pretty_Syn_Args (wrap_Args (sem_Args p) (Inh_Args [] 0 0 defaultPPConfig))
+renderArgs p       = render $ pretty_Syn_Args (wrap_Args (sem_Args p) (Inh_Args [] 0 defaultPPConfig))
 
 renderField        :: Field -> String
-renderField p      = render $ pretty_Syn_Field (wrap_Field (sem_Field p) (Inh_Field [] 0 0 defaultPPConfig))
+renderField p      = render $ pretty_Syn_Field (wrap_Field (sem_Field p) (Inh_Field [] 0 defaultPPConfig))
 
 }

--- a/src/GLuaFixer/LintSettings.hs
+++ b/src/GLuaFixer/LintSettings.hs
@@ -8,173 +8,183 @@ import GLuaFixer.LintMessage
 
 data LintSettings =
     LintSettings
-    { lint_maxScopeDepth             :: !Int
-    , lint_syntaxErrors              :: !Bool
-    , lint_syntaxInconsistencies     :: !Bool
-    , lint_deprecated                :: !Bool
-    , lint_trailingWhitespace        :: !Bool
-    , lint_whitespaceStyle           :: !Bool
-    , lint_beginnerMistakes          :: !Bool
-    , lint_emptyBlocks               :: !Bool
-    , lint_shadowing                 :: !Bool
-    , lint_gotos                     :: !Bool
-    , lint_goto_identifier           :: !Bool
-    , lint_doubleNegations           :: !Bool
-    , lint_redundantIfStatements     :: !Bool
-    , lint_redundantParentheses      :: !Bool
-    , lint_duplicateTableKeys        :: !Bool
-    , lint_profanity                 :: !Bool
-    , lint_unusedVars                :: !Bool
-    , lint_unusedParameters          :: !Bool
-    , lint_unusedLoopVars            :: !Bool
-    , lint_inconsistentVariableStyle :: !Bool
-    , lint_ignoreFiles               :: ![String]
+    { lint_maxScopeDepth               :: !Int
+    , lint_syntaxErrors                :: !Bool
+    , lint_syntaxInconsistencies       :: !Bool
+    , lint_deprecated                  :: !Bool
+    , lint_trailingWhitespace          :: !Bool
+    , lint_whitespaceStyle             :: !Bool
+    , lint_beginnerMistakes            :: !Bool
+    , lint_emptyBlocks                 :: !Bool
+    , lint_shadowing                   :: !Bool
+    , lint_gotos                       :: !Bool
+    , lint_goto_identifier             :: !Bool
+    , lint_doubleNegations             :: !Bool
+    , lint_redundantIfStatements       :: !Bool
+    , lint_redundantParentheses        :: !Bool
+    , lint_duplicateTableKeys          :: !Bool
+    , lint_profanity                   :: !Bool
+    , lint_unusedVars                  :: !Bool
+    , lint_unusedParameters            :: !Bool
+    , lint_unusedLoopVars              :: !Bool
+    , lint_inconsistentVariableStyle   :: !Bool
+    , lint_ignoreFiles                 :: ![String]
 
-    , prettyprint_spaceAfterParens   :: !Bool
-    , prettyprint_spaceAfterBrackets :: !Bool
-    , prettyprint_spaceAfterBraces   :: !Bool
-    , prettyprint_spaceEmptyParens   :: !Bool
-    , prettyprint_spaceEmptyBraces   :: !Bool
-    , prettyprint_spaceAfterLabel    :: !Bool
-    , prettyprint_spaceBeforeComma   :: !Bool
-    , prettyprint_spaceAfterComma    :: !Bool
-    , prettyprint_semicolons         :: !Bool
-    , prettyprint_cStyle             :: !Bool
-    , prettyprint_rejectInvalidCode  :: !Bool
-    , prettyprint_indentation        :: !String
+    , prettyprint_spaceAfterParens     :: !Bool
+    , prettyprint_spaceAfterBrackets   :: !Bool
+    , prettyprint_spaceAfterBraces     :: !Bool
+    , prettyprint_spaceEmptyParens     :: !Bool
+    , prettyprint_spaceEmptyBraces     :: !Bool
+    , prettyprint_spaceAfterLabel      :: !Bool
+    , prettyprint_spaceBeforeComma     :: !Bool
+    , prettyprint_spaceAfterComma      :: !Bool
+    , prettyprint_semicolons           :: !Bool
+    , prettyprint_cStyle               :: !Bool
+    , prettyprint_removeExtraParens    :: !Bool
+    , prettyprint_removeAllExtraParens :: !Bool
+    , prettyprint_rejectInvalidCode    :: !Bool
+    , prettyprint_indentation          :: !String
 
-    , log_format                     :: !LogFormatChoice
+    , log_format                       :: !LogFormatChoice
     } deriving (Show)
 
 defaultLintSettings :: LintSettings
 defaultLintSettings =
     LintSettings
-    { lint_maxScopeDepth             = 7
-    , lint_syntaxErrors              = True
-    , lint_syntaxInconsistencies     = True
-    , lint_deprecated                = True
-    , lint_trailingWhitespace        = True
-    , lint_whitespaceStyle           = True
-    , lint_beginnerMistakes          = True
-    , lint_emptyBlocks               = True
-    , lint_shadowing                 = True
-    , lint_gotos                     = True
-    , lint_goto_identifier           = True
-    , lint_doubleNegations           = True
-    , lint_redundantIfStatements     = True
-    , lint_redundantParentheses      = True
-    , lint_duplicateTableKeys        = True
-    , lint_profanity                 = True
-    , lint_unusedVars                = True
-    , lint_unusedParameters          = False
-    , lint_unusedLoopVars            = False
-    , lint_inconsistentVariableStyle = False
-    , lint_ignoreFiles               = []
+    { lint_maxScopeDepth               = 7
+    , lint_syntaxErrors                = True
+    , lint_syntaxInconsistencies       = True
+    , lint_deprecated                  = True
+    , lint_trailingWhitespace          = True
+    , lint_whitespaceStyle             = True
+    , lint_beginnerMistakes            = True
+    , lint_emptyBlocks                 = True
+    , lint_shadowing                   = True
+    , lint_gotos                       = True
+    , lint_goto_identifier             = True
+    , lint_doubleNegations             = True
+    , lint_redundantIfStatements       = True
+    , lint_redundantParentheses        = True
+    , lint_duplicateTableKeys          = True
+    , lint_profanity                   = True
+    , lint_unusedVars                  = True
+    , lint_unusedParameters            = False
+    , lint_unusedLoopVars              = False
+    , lint_inconsistentVariableStyle   = False
+    , lint_ignoreFiles                 = []
 
-    , prettyprint_spaceAfterParens   = False
-    , prettyprint_spaceAfterBrackets = False
-    , prettyprint_spaceAfterBraces   = False
-    , prettyprint_spaceEmptyParens   = True
-    , prettyprint_spaceEmptyBraces   = True
-    , prettyprint_spaceAfterLabel    = False
-    , prettyprint_spaceBeforeComma   = False
-    , prettyprint_spaceAfterComma    = True
-    , prettyprint_semicolons         = False
-    , prettyprint_cStyle             = False
-    , prettyprint_rejectInvalidCode  = False
-    , prettyprint_indentation        = "    "
+    , prettyprint_spaceAfterParens     = False
+    , prettyprint_spaceAfterBrackets   = False
+    , prettyprint_spaceAfterBraces     = False
+    , prettyprint_spaceEmptyParens     = True
+    , prettyprint_spaceEmptyBraces     = True
+    , prettyprint_spaceAfterLabel      = False
+    , prettyprint_spaceBeforeComma     = False
+    , prettyprint_spaceAfterComma      = True
+    , prettyprint_semicolons           = False
+    , prettyprint_cStyle               = False
+    , prettyprint_removeExtraParens    = True
+    , prettyprint_removeAllExtraParens = False
+    , prettyprint_rejectInvalidCode    = False
+    , prettyprint_indentation          = "    "
 
-    , log_format                     = AutoLogFormatChoice
+    , log_format                       = AutoLogFormatChoice
   }
 
 instance FromJSON LintSettings where
     parseJSON (Object v) =
         LintSettings <$>
-          v .:? "lint_maxScopeDepth"             .!= lint_maxScopeDepth defaultLintSettings             <*>
-          v .:? "lint_syntaxErrors"              .!= lint_syntaxErrors defaultLintSettings              <*>
-          v .:? "lint_syntaxInconsistencies"     .!= lint_syntaxInconsistencies defaultLintSettings     <*>
-          v .:? "lint_deprecated"                .!= lint_deprecated defaultLintSettings                <*>
-          v .:? "lint_trailingWhitespace"        .!= lint_trailingWhitespace defaultLintSettings        <*>
-          v .:? "lint_whitespaceStyle"           .!= lint_whitespaceStyle defaultLintSettings           <*>
-          v .:? "lint_beginnerMistakes"          .!= lint_beginnerMistakes defaultLintSettings          <*>
-          v .:? "lint_emptyBlocks"               .!= lint_emptyBlocks defaultLintSettings               <*>
-          v .:? "lint_shadowing"                 .!= lint_shadowing defaultLintSettings                 <*>
-          v .:? "lint_gotos"                     .!= lint_gotos defaultLintSettings                     <*>
-          v .:? "lint_goto_identifier"           .!= lint_goto_identifier defaultLintSettings           <*>
-          v .:? "lint_doubleNegations"           .!= lint_doubleNegations defaultLintSettings           <*>
-          v .:? "lint_redundantIfStatements"     .!= lint_redundantIfStatements defaultLintSettings     <*>
-          v .:? "lint_redundantParentheses"      .!= lint_redundantParentheses defaultLintSettings      <*>
-          v .:? "lint_duplicateTableKeys"        .!= lint_duplicateTableKeys defaultLintSettings        <*>
-          v .:? "lint_profanity"                 .!= lint_profanity defaultLintSettings                 <*>
-          v .:? "lint_unusedVars"                .!= lint_unusedVars defaultLintSettings                <*>
-          v .:? "lint_unusedParameters"          .!= lint_unusedParameters defaultLintSettings          <*>
-          v .:? "lint_unusedLoopVars"            .!= lint_unusedLoopVars defaultLintSettings            <*>
-          v .:? "lint_inconsistentVariableStyle" .!= lint_inconsistentVariableStyle defaultLintSettings <*>
-          v .:? "lint_ignoreFiles"               .!= lint_ignoreFiles defaultLintSettings               <*>
-          v .:? "prettyprint_spaceAfterParens"   .!= prettyprint_spaceAfterParens defaultLintSettings   <*>
-          v .:? "prettyprint_spaceAfterBrackets" .!= prettyprint_spaceAfterBrackets defaultLintSettings <*>
-          v .:? "prettyprint_spaceAfterBraces"   .!= prettyprint_spaceAfterBraces defaultLintSettings   <*>
-          v .:? "prettyprint_spaceEmptyParens"   .!= prettyprint_spaceEmptyParens defaultLintSettings   <*>
-          v .:? "prettyprint_spaceEmptyBraces"   .!= prettyprint_spaceEmptyBraces defaultLintSettings   <*>
-          v .:? "prettyprint_spaceAfterLabel"    .!= prettyprint_spaceAfterLabel defaultLintSettings    <*>
-          v .:? "prettyprint_spaceBeforeComma"   .!= prettyprint_spaceBeforeComma defaultLintSettings   <*>
-          v .:? "prettyprint_spaceAfterComma"    .!= prettyprint_spaceAfterComma defaultLintSettings    <*>
-          v .:? "prettyprint_semicolons"         .!= prettyprint_semicolons defaultLintSettings         <*>
-          v .:? "prettyprint_cStyle"             .!= prettyprint_cStyle defaultLintSettings             <*>
-          v .:? "prettyprint_rejectInvalidCode"  .!= prettyprint_rejectInvalidCode defaultLintSettings  <*>
-          v .:? "prettyprint_indentation"        .!= prettyprint_indentation defaultLintSettings        <*>
-          v .:? "log_format"                     .!= log_format defaultLintSettings
+          v .:? "lint_maxScopeDepth"               .!= lint_maxScopeDepth defaultLintSettings               <*>
+          v .:? "lint_syntaxErrors"                .!= lint_syntaxErrors defaultLintSettings                <*>
+          v .:? "lint_syntaxInconsistencies"       .!= lint_syntaxInconsistencies defaultLintSettings       <*>
+          v .:? "lint_deprecated"                  .!= lint_deprecated defaultLintSettings                  <*>
+          v .:? "lint_trailingWhitespace"          .!= lint_trailingWhitespace defaultLintSettings          <*>
+          v .:? "lint_whitespaceStyle"             .!= lint_whitespaceStyle defaultLintSettings             <*>
+          v .:? "lint_beginnerMistakes"            .!= lint_beginnerMistakes defaultLintSettings            <*>
+          v .:? "lint_emptyBlocks"                 .!= lint_emptyBlocks defaultLintSettings                 <*>
+          v .:? "lint_shadowing"                   .!= lint_shadowing defaultLintSettings                   <*>
+          v .:? "lint_gotos"                       .!= lint_gotos defaultLintSettings                       <*>
+          v .:? "lint_goto_identifier"             .!= lint_goto_identifier defaultLintSettings             <*>
+          v .:? "lint_doubleNegations"             .!= lint_doubleNegations defaultLintSettings             <*>
+          v .:? "lint_redundantIfStatements"       .!= lint_redundantIfStatements defaultLintSettings       <*>
+          v .:? "lint_redundantParentheses"        .!= lint_redundantParentheses defaultLintSettings        <*>
+          v .:? "lint_duplicateTableKeys"          .!= lint_duplicateTableKeys defaultLintSettings          <*>
+          v .:? "lint_profanity"                   .!= lint_profanity defaultLintSettings                   <*>
+          v .:? "lint_unusedVars"                  .!= lint_unusedVars defaultLintSettings                  <*>
+          v .:? "lint_unusedParameters"            .!= lint_unusedParameters defaultLintSettings            <*>
+          v .:? "lint_unusedLoopVars"              .!= lint_unusedLoopVars defaultLintSettings              <*>
+          v .:? "lint_inconsistentVariableStyle"   .!= lint_inconsistentVariableStyle defaultLintSettings   <*>
+          v .:? "lint_ignoreFiles"                 .!= lint_ignoreFiles defaultLintSettings                 <*>
+          v .:? "prettyprint_spaceAfterParens"     .!= prettyprint_spaceAfterParens defaultLintSettings     <*>
+          v .:? "prettyprint_spaceAfterBrackets"   .!= prettyprint_spaceAfterBrackets defaultLintSettings   <*>
+          v .:? "prettyprint_spaceAfterBraces"     .!= prettyprint_spaceAfterBraces defaultLintSettings     <*>
+          v .:? "prettyprint_spaceEmptyParens"     .!= prettyprint_spaceEmptyParens defaultLintSettings     <*>
+          v .:? "prettyprint_spaceEmptyBraces"     .!= prettyprint_spaceEmptyBraces defaultLintSettings     <*>
+          v .:? "prettyprint_spaceAfterLabel"      .!= prettyprint_spaceAfterLabel defaultLintSettings      <*>
+          v .:? "prettyprint_spaceBeforeComma"     .!= prettyprint_spaceBeforeComma defaultLintSettings     <*>
+          v .:? "prettyprint_spaceAfterComma"      .!= prettyprint_spaceAfterComma defaultLintSettings      <*>
+          v .:? "prettyprint_semicolons"           .!= prettyprint_semicolons defaultLintSettings           <*>
+          v .:? "prettyprint_cStyle"               .!= prettyprint_cStyle defaultLintSettings               <*>
+          v .:? "prettyprint_removeExtraParens"    .!= prettyprint_removeExtraParens defaultLintSettings    <*>
+          v .:? "prettyprint_removeAllExtraParens" .!= prettyprint_removeAllExtraParens defaultLintSettings <*>
+          v .:? "prettyprint_rejectInvalidCode"    .!= prettyprint_rejectInvalidCode defaultLintSettings    <*>
+          v .:? "prettyprint_indentation"          .!= prettyprint_indentation defaultLintSettings          <*>
+          v .:? "log_format"                       .!= log_format defaultLintSettings
 
     parseJSON _          = mzero
 
 lint2ppSetting :: LintSettings -> PrettyPrintConfig
 lint2ppSetting ls =
     PPConfig
-    { spaceAfterParens   = prettyprint_spaceAfterParens ls
-    , spaceAfterBrackets = prettyprint_spaceAfterBrackets ls
-    , spaceAfterBraces   = prettyprint_spaceAfterBraces ls
-    , spaceEmptyParens   = prettyprint_spaceEmptyParens ls
-    , spaceEmptyBraces   = prettyprint_spaceEmptyBraces ls
-    , spaceAfterLabel    = prettyprint_spaceAfterLabel ls
-    , spaceBeforeComma   = prettyprint_spaceBeforeComma ls
-    , spaceAfterComma    = prettyprint_spaceAfterComma ls
-    , semicolons         = prettyprint_semicolons ls
-    , cStyle             = prettyprint_cStyle ls
-    , indentation        = prettyprint_indentation ls
+    { spaceAfterParens     = prettyprint_spaceAfterParens ls
+    , spaceAfterBrackets   = prettyprint_spaceAfterBrackets ls
+    , spaceAfterBraces     = prettyprint_spaceAfterBraces ls
+    , spaceEmptyParens     = prettyprint_spaceEmptyParens ls
+    , spaceEmptyBraces     = prettyprint_spaceEmptyBraces ls
+    , spaceAfterLabel      = prettyprint_spaceAfterLabel ls
+    , spaceBeforeComma     = prettyprint_spaceBeforeComma ls
+    , spaceAfterComma      = prettyprint_spaceAfterComma ls
+    , semicolons           = prettyprint_semicolons ls
+    , cStyle               = prettyprint_cStyle ls
+    , removeExtraParens    = prettyprint_removeExtraParens ls
+    , removeAllExtraParens = prettyprint_removeAllExtraParens ls
+    , indentation          = prettyprint_indentation ls
     }
 
 instance ToJSON LintSettings where
     toJSON ls = object
-        [ "lint_maxScopeDepth"             .= lint_maxScopeDepth ls
-        , "lint_syntaxErrors"              .= lint_syntaxErrors ls
-        , "lint_syntaxInconsistencies"     .= lint_syntaxInconsistencies ls
-        , "lint_deprecated"                .= lint_deprecated ls
-        , "lint_trailingWhitespace"        .= lint_trailingWhitespace ls
-        , "lint_whitespaceStyle"           .= lint_whitespaceStyle ls
-        , "lint_beginnerMistakes"          .= lint_beginnerMistakes ls
-        , "lint_emptyBlocks"               .= lint_emptyBlocks ls
-        , "lint_shadowing"                 .= lint_shadowing ls
-        , "lint_gotos"                     .= lint_gotos ls
-        , "lint_goto_identifier"           .= lint_goto_identifier ls
-        , "lint_doubleNegations"           .= lint_doubleNegations ls
-        , "lint_redundantIfStatements"     .= lint_redundantIfStatements ls
-        , "lint_redundantParentheses"      .= lint_redundantParentheses ls
-        , "lint_duplicateTableKeys"        .= lint_duplicateTableKeys ls
-        , "lint_profanity"                 .= lint_profanity ls
-        , "lint_unusedVars"                .= lint_unusedVars ls
-        , "lint_unusedParameters"          .= lint_unusedParameters ls
-        , "lint_unusedLoopVars"            .= lint_unusedLoopVars ls
-        , "lint_inconsistentVariableStyle" .= lint_inconsistentVariableStyle ls
-        , "prettyprint_spaceAfterParens"   .= prettyprint_spaceAfterParens ls
-        , "prettyprint_spaceAfterBrackets" .= prettyprint_spaceAfterBrackets ls
-        , "prettyprint_spaceAfterBraces"   .= prettyprint_spaceAfterBraces ls
-        , "prettyprint_spaceEmptyParens"   .= prettyprint_spaceEmptyParens ls
-        , "prettyprint_spaceEmptyBraces"   .= prettyprint_spaceEmptyBraces ls
-        , "prettyprint_spaceAfterLabel"    .= prettyprint_spaceAfterLabel ls
-        , "prettyprint_spaceBeforeComma"   .= prettyprint_spaceBeforeComma ls
-        , "prettyprint_spaceAfterComma"    .= prettyprint_spaceAfterComma ls
-        , "prettyprint_semicolons"         .= prettyprint_semicolons ls
-        , "prettyprint_cStyle"             .= prettyprint_cStyle ls
-        , "prettyprint_indentation"        .= prettyprint_indentation ls
-        , "log_format"                     .= log_format ls
+        [ "lint_maxScopeDepth"               .= lint_maxScopeDepth ls
+        , "lint_syntaxErrors"                .= lint_syntaxErrors ls
+        , "lint_syntaxInconsistencies"       .= lint_syntaxInconsistencies ls
+        , "lint_deprecated"                  .= lint_deprecated ls
+        , "lint_trailingWhitespace"          .= lint_trailingWhitespace ls
+        , "lint_whitespaceStyle"             .= lint_whitespaceStyle ls
+        , "lint_beginnerMistakes"            .= lint_beginnerMistakes ls
+        , "lint_emptyBlocks"                 .= lint_emptyBlocks ls
+        , "lint_shadowing"                   .= lint_shadowing ls
+        , "lint_gotos"                       .= lint_gotos ls
+        , "lint_goto_identifier"             .= lint_goto_identifier ls
+        , "lint_doubleNegations"             .= lint_doubleNegations ls
+        , "lint_redundantIfStatements"       .= lint_redundantIfStatements ls
+        , "lint_redundantParentheses"        .= lint_redundantParentheses ls
+        , "lint_duplicateTableKeys"          .= lint_duplicateTableKeys ls
+        , "lint_profanity"                   .= lint_profanity ls
+        , "lint_unusedVars"                  .= lint_unusedVars ls
+        , "lint_unusedParameters"            .= lint_unusedParameters ls
+        , "lint_unusedLoopVars"              .= lint_unusedLoopVars ls
+        , "lint_inconsistentVariableStyle"   .= lint_inconsistentVariableStyle ls
+        , "prettyprint_spaceAfterParens"     .= prettyprint_spaceAfterParens ls
+        , "prettyprint_spaceAfterBrackets"   .= prettyprint_spaceAfterBrackets ls
+        , "prettyprint_spaceAfterBraces"     .= prettyprint_spaceAfterBraces ls
+        , "prettyprint_spaceEmptyParens"     .= prettyprint_spaceEmptyParens ls
+        , "prettyprint_spaceEmptyBraces"     .= prettyprint_spaceEmptyBraces ls
+        , "prettyprint_spaceAfterLabel"      .= prettyprint_spaceAfterLabel ls
+        , "prettyprint_spaceBeforeComma"     .= prettyprint_spaceBeforeComma ls
+        , "prettyprint_spaceAfterComma"      .= prettyprint_spaceAfterComma ls
+        , "prettyprint_semicolons"           .= prettyprint_semicolons ls
+        , "prettyprint_cStyle"               .= prettyprint_cStyle ls
+        , "prettyprint_removeExtraParens"    .= prettyprint_removeExtraParens ls
+        , "prettyprint_removeAllExtraParens" .= prettyprint_removeAllExtraParens ls
+        , "prettyprint_indentation"          .= prettyprint_indentation ls
+        , "log_format"                       .= log_format ls
         ]

--- a/src/GLuaFixer/LintSettings.hs
+++ b/src/GLuaFixer/LintSettings.hs
@@ -40,8 +40,8 @@ data LintSettings =
     , prettyprint_spaceAfterComma      :: !Bool
     , prettyprint_semicolons           :: !Bool
     , prettyprint_cStyle               :: !Bool
-    , prettyprint_removeExtraParens    :: !Bool
-    , prettyprint_removeAllExtraParens :: !Bool
+    , prettyprint_removeRedundantParens:: !Bool
+    , prettyprint_minimizeParens       :: !Bool
     , prettyprint_rejectInvalidCode    :: !Bool
     , prettyprint_indentation          :: !String
 
@@ -83,8 +83,8 @@ defaultLintSettings =
     , prettyprint_spaceAfterComma      = True
     , prettyprint_semicolons           = False
     , prettyprint_cStyle               = False
-    , prettyprint_removeExtraParens    = True
-    , prettyprint_removeAllExtraParens = False
+    , prettyprint_removeRedundantParens= True
+    , prettyprint_minimizeParens       = False
     , prettyprint_rejectInvalidCode    = False
     , prettyprint_indentation          = "    "
 
@@ -125,8 +125,8 @@ instance FromJSON LintSettings where
           v .:? "prettyprint_spaceAfterComma"      .!= prettyprint_spaceAfterComma defaultLintSettings      <*>
           v .:? "prettyprint_semicolons"           .!= prettyprint_semicolons defaultLintSettings           <*>
           v .:? "prettyprint_cStyle"               .!= prettyprint_cStyle defaultLintSettings               <*>
-          v .:? "prettyprint_removeExtraParens"    .!= prettyprint_removeExtraParens defaultLintSettings    <*>
-          v .:? "prettyprint_removeAllExtraParens" .!= prettyprint_removeAllExtraParens defaultLintSettings <*>
+          v .:? "prettyprint_removeRedundantParens".!= prettyprint_removeRedundantParens defaultLintSettings<*>
+          v .:? "prettyprint_minimizeParens"       .!= prettyprint_minimizeParens defaultLintSettings       <*>
           v .:? "prettyprint_rejectInvalidCode"    .!= prettyprint_rejectInvalidCode defaultLintSettings    <*>
           v .:? "prettyprint_indentation"          .!= prettyprint_indentation defaultLintSettings          <*>
           v .:? "log_format"                       .!= log_format defaultLintSettings
@@ -146,8 +146,8 @@ lint2ppSetting ls =
     , spaceAfterComma      = prettyprint_spaceAfterComma ls
     , semicolons           = prettyprint_semicolons ls
     , cStyle               = prettyprint_cStyle ls
-    , removeExtraParens    = prettyprint_removeExtraParens ls
-    , removeAllExtraParens = prettyprint_removeAllExtraParens ls
+    , removeRedundantParens= prettyprint_removeRedundantParens ls
+    , minimizeParens       = prettyprint_minimizeParens ls
     , indentation          = prettyprint_indentation ls
     }
 
@@ -183,8 +183,8 @@ instance ToJSON LintSettings where
         , "prettyprint_spaceAfterComma"      .= prettyprint_spaceAfterComma ls
         , "prettyprint_semicolons"           .= prettyprint_semicolons ls
         , "prettyprint_cStyle"               .= prettyprint_cStyle ls
-        , "prettyprint_removeExtraParens"    .= prettyprint_removeExtraParens ls
-        , "prettyprint_removeAllExtraParens" .= prettyprint_removeAllExtraParens ls
+        , "prettyprint_removeRedundantParens".= prettyprint_removeRedundantParens ls
+        , "prettyprint_minimizeParens"       .= prettyprint_minimizeParens ls
         , "prettyprint_indentation"          .= prettyprint_indentation ls
         , "log_format"                       .= log_format ls
         ]


### PR DESCRIPTION
Removes unnecessary parenthesis.

It has two levels:
- `prettyprint_removeExtraParens` will only remove parenthesis on the top level of an expression (`x = (1 + 1)`) or around things which definitely don't need them (variables, unsuffixed constants, other things already wrapped in parens). This is on by default.
- `prettyprint_removeAllExtraParens` will remove parenthesis when operator precedence rules allow. Off by default. I chose to leave this off because people don't necessarily know all of the precedence rules and stripping them all may reduce readability.

I would really prefer if the less aggressive setting (if not the full setting) is on by default because I feel like I see a lot of parenthesis spam in GLua. Let me know if I need to change anything for this to be permissible.

This has been tested on a lot of code. It does not erroneously change behavior.

#113 