### PR TITLE
Improve GH formatting

### DIFF
--- a/src/GLuaFixer/LintMessage.hs
+++ b/src/GLuaFixer/LintMessage.hs
@@ -85,7 +85,7 @@ formatLintMessageDefault (LintMessage severity region msg file) =
     ""
 
 formatLintMessageGithub :: LintMessage -> String
-formatLintMessageGithub (LintMessage severity (Region (LineColPos line col _) _) msg file) =
+formatLintMessageGithub (LintMessage severity (Region (LineColPos line col _) (LineColPos endLine endCol _)) msg file) =
   let
     level = case severity of
       LintWarning -> "warning"
@@ -95,6 +95,8 @@ formatLintMessageGithub (LintMessage severity (Region (LineColPos line col _) _)
     showString " file=" . showString file .
     showString ",line=" . shows (succ line) .
     showString ",col=" . shows (succ col) .
+    showString ",endLine=" . shows (succ endLine) .
+    showString ",endColumn=" . shows (succ endCol) .
     showString "::" . showString msg $
     ""
 


### PR DESCRIPTION
Github actions allows `endColumn` and `endLine` parameters in output messages. ([ref](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message))

The tangible benefits here are probably pretty slim.
Basically, in this situation:
![image](https://user-images.githubusercontent.com/7936439/162600139-a642a9cf-66c1-4052-88c5-108cfe539f9d.png)

The annotation would appear below the internal block rather than on the first line. Like so:
![image](https://user-images.githubusercontent.com/7936439/162600478-3e686766-5a06-4d55-b016-9004b9fe6378.png)



There have been rumors that GH will make these annotations look more like block Suggestions (🤞)
If that happens, this change will be even more valuable.


**Sidenote**
These messages also allow a `title` field.
If GLuaFixer had a concept of `shortDescription` and `fullDescription`, or a `ruleName` and `ruleDescription`, we could set the `title` to something that would look a little nicer.

Based on the current messages, you could basically split them at the first period and use the first half as the short description.

Just a thought