### PR TITLE
Add GitHub actions to check code

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,3 +13,8 @@ jobs:
         with:
           name: glualint
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - name: Build Nix environment
+        run:
+          cachix watch-exec glualint -- nix print-dev-env .#ci > "$HOME/.devenv"
+      - name: Activate Nix environment
+        run: source "$HOME/.devenv"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
         run:
           cachix watch-exec glualint -- nix print-dev-env --accept-flake-config .#ci > "$HOME/.devenv"
       - name: Activate Nix environment
-        run: source "$HOME/.devenv"
+        run: source "$HOME/.devenv" && env >> "$GITHUB_ENV"
 
       - run: cabal check
       - run: cabal-fmt --check --Werror glualint.cabal

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,9 @@
 name: Lint and test glualint
-on: [pull_request, push]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 jobs:
   lint-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,15 @@
+name: Lint and test glualint
+on: [pull_request, push]
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - uses: cachix/install-nix-action@v22
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@v12
+        with:
+          name: glualint
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,9 +16,10 @@ jobs:
       - uses: cachix/cachix-action@v12
         with:
           name: glualint
+          extraPullNames: glualint
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - name: Build Nix environment
         run:
-          cachix watch-exec glualint -- nix print-dev-env .#ci > "$HOME/.devenv"
+          cachix watch-exec glualint -- nix print-dev-env --accept-flake-config .#ci > "$HOME/.devenv"
       - name: Activate Nix environment
         run: source "$HOME/.devenv"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,3 +23,18 @@ jobs:
           cachix watch-exec glualint -- nix print-dev-env --accept-flake-config .#ci > "$HOME/.devenv"
       - name: Activate Nix environment
         run: source "$HOME/.devenv"
+
+      - run: cabal check
+      - run: cabal-fmt --check --Werror glualint.cabal
+
+      # Note: This check must run BEFORE the AG files are compiled to Haskell
+      # files. Those files are generated with no regard to fourmolu's style, so
+      # fourmolu would throw errors for them.
+      # TODO: Find a way to properly exclude them.
+      - run: fourmolu --mode check app src
+
+      - name: Generate .hs files from .ag
+        run: ./AGGenerator.sh
+
+      - run: cabal run glualint -- test testcase.lua tests
+      - run: cabal run golden


### PR DESCRIPTION
Lately I've been leveling up the code quality of glualint. This includes:

- Adding and applying a formatter for Haskell files (`fourmolu`)
- Adding and applying a formatter for the cabal file (`cabal-fmt`)
- Unit tests using `tasty`
- Uploading glualint-lib to hackage, which means the cabal file should pass `cabal check`

Beyond that there is still the very bare-bones unit test that consists of just running `glualint test testcase.lua`. A test that is stupid simple, but has saved me from a lot of bugs in the past few years.

The next step is running all these things on CI. Since I am the sole maintainer, I still push directly to master without going through pull requests. Occasionally for bigger features I branch off, but otherwise going directly to master is the most efficient way of working. With GitHub actions, I'll get an email if any of the above checks fail.

This PR sets up the GitHub actions.