### PR TITLE
Better pretty printing for comments at end of block

### DIFF
--- a/src/GLua/AG/AST.ag
+++ b/src/GLua/AG/AST.ag
@@ -33,7 +33,7 @@ type Else      = maybe MElse
 data AST          | AST comments :: {[MToken]} chunk :: Block
 
 -- Block of code
-data Block        | Block  stats :: MStatList    ret :: AReturn
+data Block        | Block pos :: Region stats :: MStatList ret :: AReturn
 
 data MStat        | MStat    pos :: Region  stat :: Stat
 

--- a/src/GLua/AG/PrettyPrint.ag
+++ b/src/GLua/AG/PrettyPrint.ag
@@ -629,10 +629,13 @@ sem Block
     | Block
         lhs.pretty =
            if @loc.isMultiline
-           then @stats.pretty $+$ @ret.pretty
+           then @stats.pretty $+$ @ret.pretty $+$ @loc.prettyCommentsAfter
            else @stats.pretty <-> @ret.pretty
         loc.statementCount = @stats.statementCount + @ret.statementCount
-        loc.isMultiline = @stats.isMultiline || @ret.isMultiline || @loc.statementCount > 1
+        loc.isMultiline = @stats.isMultiline || @ret.isMultiline || @loc.statementCount > 1 || not (null $ fst $ @loc.commentsAfter)
+        loc.commentsAfter = span (\(MToken pos _) -> pos `beforeEnd` @pos) @ret.comments
+        loc.prettyCommentsAfter = renderMLComments @lhs.ppconf @lhs.indent $ fst @loc.commentsAfter
+        lhs.comments = snd @loc.commentsAfter
 
 sem Stat
     | Def

--- a/src/GLua/Position.hs
+++ b/src/GLua/Position.hs
@@ -56,3 +56,28 @@ rgOr :: Region -> Region -> Region
 rgOr l r
   | l == emptyRg = r
   | otherwise = l
+
+-- | Whether the first region ends strictly before the second region starts
+before :: Region -> Region -> Bool
+before (Region _ (LineColPos _ _ p)) (Region (LineColPos _ _ p') _) = p < p'
+
+-- | Whether the first region ends before or on the same line as the second region
+beforeOrOnLine :: Region -> Region -> Bool
+beforeOrOnLine (Region _ (LineColPos l _ _)) (Region (LineColPos l' _ _) _) = l <= l'
+
+-- | Whether the first region ends before the second region ends
+beforeEnd :: Region -> Region -> Bool
+beforeEnd (Region _ (LineColPos _ _ p)) (Region _ (LineColPos _ _ p')) = p < p'
+
+-- | Whether the first region ends before or on the same line as the END of the second region
+beforeEndLine :: Region -> Region -> Bool
+beforeEndLine (Region _ (LineColPos l _ _)) (Region _ (LineColPos l' _ _)) = l <= l'
+
+-- | Returns a region that starts at the start of the first region
+-- and ends BEFORE the start of the second region
+upto :: Region -> Region -> Region
+upto lr rr = case (rgEnd lr, rgStart rr) of
+  (_, LineColPos 0 0 0) -> lr
+  (LineColPos l c _, LineColPos l' c' _)
+    | l' > l || (l' == l && c' > c) -> lr
+    | otherwise -> Region (rgStart lr) (rgStart rr)

--- a/src/GLua/TokenTypes.hs
+++ b/src/GLua/TokenTypes.hs
@@ -55,31 +55,6 @@ customAdvanceStr = foldl' customAdvanceChr
 customAdvanceToken :: LineColPos -> Token -> LineColPos
 customAdvanceToken (LineColPos line pos' abs') t = let len = tokenSize t in LineColPos line (pos' + len) (abs' + len)
 
--- | Whether the first region ends strictly before the second region starts
-before :: Region -> Region -> Bool
-before (Region _ (LineColPos _ _ p)) (Region (LineColPos _ _ p') _) = p < p'
-
--- | Whether the first region ends before or on the same line as the second region
-beforeOrOnLine :: Region -> Region -> Bool
-beforeOrOnLine (Region _ (LineColPos l _ _)) (Region (LineColPos l' _ _) _) = l <= l'
-
--- | Whether the first region ends before the second region ends
-beforeEnd :: Region -> Region -> Bool
-beforeEnd (Region _ (LineColPos _ _ p)) (Region _ (LineColPos _ _ p')) = p < p'
-
--- | Whether the first region ends before or on the same line as the END of the second region
-beforeEndLine :: Region -> Region -> Bool
-beforeEndLine (Region _ (LineColPos l _ _)) (Region _ (LineColPos l' _ _)) = l <= l'
-
--- | Returns a region that starts at the start of the first region
--- and ends BEFORE the start of the second region
-upto :: Region -> Region -> Region
-upto lr rr = case (rgEnd lr, rgStart rr) of
-  (_, LineColPos 0 0 0) -> lr
-  (LineColPos l c _, LineColPos l' c' _)
-    | l' > l || (l' == l && c' > c) -> lr
-    | otherwise -> Region (rgStart lr) (rgStart rr)
-
 -- | Fold over metatoken
 foldMToken :: MTokenAlgebra t -> MToken -> t
 foldMToken alg (MToken p t) = alg p t

--- a/tests/golden/data/input/various-comments.lua
+++ b/tests/golden/data/input/various-comments.lua
@@ -56,6 +56,8 @@ end
 local function foo() -- same-line-comment
 end
 
+-- Rendering of comments after return (or instead of return) reported here:
+-- https://github.com/FPtje/GLuaFixer/issues/170#issuecomment-1828253356
 function foo()
     -- Comment before return
     return 1, 2, 3 -- comment on same line as return

--- a/tests/golden/data/output/issue-106.lua
+++ b/tests/golden/data/output/issue-106.lua
@@ -1,5 +1,7 @@
 a(
     {b},
-    function() end, -- comment
+    function()
+        -- comment
+    end,
     function() end
 )

--- a/tests/golden/data/output/various-comments.lua
+++ b/tests/golden/data/output/various-comments.lua
@@ -1,6 +1,8 @@
 -- Comment before if-statement
-if false then end -- same-line comment
--- print("TODO")
+if false then -- same-line comment
+    -- print("TODO")
+end
+
 if true then
     a = 2 -- bar
 end
@@ -26,28 +28,33 @@ if true then
 end
 
 -- Comment before if-statement
-if true then return end
--- comment after return on new line
+if true then
+    return
+    -- comment after return on new line
+end
+
 -- Comment before if-statement
 if true then return end
 -- comment after end
 if true or false then return end --[[ comment in condition]] -- single line comment in condition
 for var = 1, 10 do -- same-line comment
+    -- print("TODO")
 end
 
--- print("TODO")
 for k, v in pairs(player.GetAll()) do -- same-line comment
+    -- print("TODO")
 end
 
--- print("TODO")
 function foo() -- same-line-comment
 end
 
 local function foo() -- same-line-comment
 end
 
+-- Rendering of comments after return (or instead of return) reported here:
+-- https://github.com/FPtje/GLuaFixer/issues/170#issuecomment-1828253356
 function foo()
     -- Comment before return
     return 1, 2, 3 -- comment on same line as return
+    -- comment after return
 end
--- comment after return


### PR DESCRIPTION
Fixes problem mentioned in https://github.com/FPtje/GLuaFixer/issues/170#issuecomment-1828253356

The updated tests show the difference, but here's a minimal example that shows the difference.

Input:

```lua
function foo()
    -- Comment before return
    return 1, 2, 3 -- comment on same line as return
    -- comment after return
end
```

Before:

```lua
function foo()
    -- Comment before return
    return 1, 2, 3 -- comment on same line as return
end
-- comment after return
```

After:

```lua
function foo()
    -- Comment before return
    return 1, 2, 3 -- comment on same line as return
    -- comment after return
end
```