### PR TITLE
Update workflow utils

### DIFF
--- a/.github/workflows/glualint.yml
+++ b/.github/workflows/glualint.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: project
 
       - name: Get GluaLint Download Link
         id: download-link
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           retries: 5
           script: |


### PR DESCRIPTION
[`checkout`](https://github.com/actions/checkout) and [`github-script`](https://github.com/actions/github-script) both have version updates to handle the new node upgrades.

I left the `lint.yml` alone because it uses other tools I'm not familiar with, and may require some investigation.

To my knowledge, these two upgrades are safe.

Addresses these warnings when using the reusable workflow:
![image](https://github.com/FPtje/GLuaFixer/assets/7936439/27fb9004-52fa-4cb0-ae4a-bb0a8fd37b1b)
