### PR TITLE
Fix nix setup, and upgrade actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,18 +9,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v22
+        uses: actions/checkout@v6.0.2
+      - uses: cachix/install-nix-action@v31.10.4
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@v12
+      - uses: cachix/cachix-action@v17
         with:
           name: glualint
-          extraPullNames: glualint
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - name: Build Nix environment
-        run:
-          cachix watch-exec glualint -- nix print-dev-env --accept-flake-config .#ci > "$HOME/.devenv"
+        run: cachix watch-exec glualint -- nix print-dev-env --accept-flake-config .#ci > "$HOME/.devenv"
       - name: Activate Nix environment
         run: source "$HOME/.devenv" && env >> "$GITHUB_ENV"
 


### PR DESCRIPTION
Looks like somewhere along the line the GitHub action bitrotted. See ~~https://github.com/FPtje/DarkRP/issues/3298~~ https://github.com/FPtje/GLuaFixer/pull/186, which fails with an error about the cachix key not being set. Even after refreshing that token, the error is still thrown. This PR iterates to fix that.