### PR TITLE
Add lint_warningsAreErrors setting to LintSettings

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Example `glualint.json` with the default options:
     "prettyprint_assumeOperatorAssociativity": true,
     "prettyprint_indentation": "    ",
 
-    "log_format": "auto",
+    "log_format": "auto"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ Example `glualint.json` with the default options:
     "prettyprint_assumeOperatorAssociativity": true,
     "prettyprint_indentation": "    ",
 
-    "log_format": "auto"
+    "log_format": "auto",
+    "lint_warningsAreErrors": true
 }
 ```
 
@@ -118,6 +119,7 @@ Option | Description
 `lint_spaceBeforeComma` | Whether to warn about spaces before the comma. This option depends on `prettyprint_spaceBeforeComma` on whether the space is wanted.
 `lint_spaceAfterComma` | Whether to warn about spaces after the comma. This option depends on `prettyprint_spaceAfterComma` on whether the space is wanted.
 `lint_maxLineLength` | Warn for lines longer than the given number. Set to 0 to disable.
+`lint_warningsAreErrors` | Whether warnings should cause a non-zero exit code. Set to `false` to only fail on errors (syntax errors, parse errors) but not warnings.
 
 ### Pretty print options
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Example `glualint.json` with the default options:
     "lint_spaceBeforeComma": false,
     "lint_spaceAfterComma": false,
     "lint_maxLineLength": 0,
+    "lint_warningsAreErrors": true,
 
     "prettyprint_spaceBetweenParens": false,
     "prettyprint_spaceBetweenBrackets": false,
@@ -82,7 +83,6 @@ Example `glualint.json` with the default options:
     "prettyprint_indentation": "    ",
 
     "log_format": "auto",
-    "lint_warningsAreErrors": true
 }
 ```
 

--- a/app/GLuaFixer/Effects/Run.hs
+++ b/app/GLuaFixer/Effects/Run.hs
@@ -28,7 +28,7 @@ import GLuaFixer.Effects.Interruptible (Interruptible, interruptibleFoldMStrict)
 import GLuaFixer.Effects.Logging (Logging, emitLintMessage, getLogFormat, putStrLnStdError, putStrLnStdOut, putStrStdOut)
 import GLuaFixer.Effects.Settings (Settings, SettingsError (CouldNotParseSettings), getSettingsForFile, runSettings, traceSettingsIfEnabled)
 import qualified GLuaFixer.Interface as Interface
-import GLuaFixer.LintMessage (sortLintMessages)
+import GLuaFixer.LintMessage (sortLintMessages, Severity (..), LintMessage (..))
 import GLuaFixer.LintSettings (
   LintSettings (..),
   StdInOrFiles (..),
@@ -249,8 +249,14 @@ lint lintSettings filepath contents = do
           let
             astLint = Interface.astLint filepath lintSettings ast
             msgs = sortLintMessages $ sourceLint ++ lextLint ++ astLint
+            hasErrors = any ((== LintError) . lintmsg_severity) msgs
+            hasWarnings = any ((== LintWarning) . lintmsg_severity) msgs
+            exitCode = case (hasErrors, hasWarnings) of
+              (True, _) -> ExitFailure 1
+              (_, True) | lintSettings.lint_warningsAreErrors -> ExitFailure 1
+              _ -> ExitSuccess
           mapM_ (emitLintMessage logFormat) msgs
-          pure $ if null msgs then ExitSuccess else ExitFailure 1
+          pure exitCode
 
 -- | Pretty print a file
 prettyprint

--- a/app/GLuaFixer/Effects/Run.hs
+++ b/app/GLuaFixer/Effects/Run.hs
@@ -28,7 +28,7 @@ import GLuaFixer.Effects.Interruptible (Interruptible, interruptibleFoldMStrict)
 import GLuaFixer.Effects.Logging (Logging, emitLintMessage, getLogFormat, putStrLnStdError, putStrLnStdOut, putStrStdOut)
 import GLuaFixer.Effects.Settings (Settings, SettingsError (CouldNotParseSettings), getSettingsForFile, runSettings, traceSettingsIfEnabled)
 import qualified GLuaFixer.Interface as Interface
-import GLuaFixer.LintMessage (sortLintMessages, Severity (..), LintMessage (..))
+import GLuaFixer.LintMessage (LintMessage (..), Severity (..), sortLintMessages)
 import GLuaFixer.LintSettings (
   LintSettings (..),
   StdInOrFiles (..),

--- a/src/GLuaFixer/LintSettings.hs
+++ b/src/GLuaFixer/LintSettings.hs
@@ -57,8 +57,9 @@ data LintSettings = LintSettings
   , lint_unusedVars :: !Bool
   , lint_unusedParameters :: !Bool
   , lint_unusedLoopVars :: !Bool
-  , lint_inconsistentVariableStyle :: !Bool
-  , lint_spaceBetweenParens :: !Bool
+, lint_inconsistentVariableStyle :: !Bool
+   , lint_warningsAreErrors :: !Bool
+   , lint_spaceBetweenParens :: !Bool
   , lint_spaceBetweenBrackets :: !Bool
   , lint_spaceBetweenBraces :: !Bool
   , lint_spaceBeforeComma :: !Bool
@@ -106,6 +107,7 @@ defaultLintSettings =
     , lint_unusedParameters = False
     , lint_unusedLoopVars = False
     , lint_inconsistentVariableStyle = False
+    , lint_warningsAreErrors = True
     , lint_spaceBetweenParens = False
     , lint_spaceBetweenBrackets = False
     , lint_spaceBetweenBraces = False
@@ -153,6 +155,7 @@ instance FromJSON LintSettings where
       <*> v .:? "lint_unusedParameters" .!= lint_unusedParameters defaultLintSettings
       <*> v .:? "lint_unusedLoopVars" .!= lint_unusedLoopVars defaultLintSettings
       <*> v .:? "lint_inconsistentVariableStyle" .!= lint_inconsistentVariableStyle defaultLintSettings
+      <*> v .:? "lint_warningsAreErrors" .!= lint_warningsAreErrors defaultLintSettings
       <*>
       -- Backwards compatible change: accept both the newer spaceBetween and the older
       -- spaceAfter
@@ -234,6 +237,7 @@ instance ToJSON LintSettings where
       , "lint_unusedParameters" .= lint_unusedParameters ls
       , "lint_unusedLoopVars" .= lint_unusedLoopVars ls
       , "lint_inconsistentVariableStyle" .= lint_inconsistentVariableStyle ls
+      , "lint_warningsAreErrors" .= lint_warningsAreErrors ls
       , "lint_spaceBetweenParens" .= lint_spaceBetweenParens ls
       , "lint_spaceBetweenBrackets" .= lint_spaceBetweenBrackets ls
       , "lint_spaceBetweenBraces" .= lint_spaceBetweenBraces ls

--- a/src/GLuaFixer/LintSettings.hs
+++ b/src/GLuaFixer/LintSettings.hs
@@ -57,9 +57,9 @@ data LintSettings = LintSettings
   , lint_unusedVars :: !Bool
   , lint_unusedParameters :: !Bool
   , lint_unusedLoopVars :: !Bool
-, lint_inconsistentVariableStyle :: !Bool
-   , lint_warningsAreErrors :: !Bool
-   , lint_spaceBetweenParens :: !Bool
+  , lint_inconsistentVariableStyle :: !Bool
+  , lint_warningsAreErrors :: !Bool
+  , lint_spaceBetweenParens :: !Bool
   , lint_spaceBetweenBrackets :: !Bool
   , lint_spaceBetweenBraces :: !Bool
   , lint_spaceBeforeComma :: !Bool


### PR DESCRIPTION
This simply adds the "lint_warningsAreErrors" option.
This option shows the warnings normally, but if set to false, returns a exitcode of 0, instead of 1.
This is usefull, if you use it in ci/cd pipelines and don't really care about warnings.