### PR TITLE
Remove warnings for ai.GetScheduleID and ai.GetTaskID

### DIFF
--- a/src/GLuaFixer/BadSequenceFinder.hs
+++ b/src/GLuaFixer/BadSequenceFinder.hs
@@ -55,13 +55,6 @@ libraryWarnings s p = do
 
   p
 
--- | Warnings for the ai library
-aiWarnings :: AParser String
-aiWarnings =
-  libraryWarnings "ai" $
-    "The function is broken" <$ ident "GetScheduleID"
-      <|> "The function is broken" <$ ident "GetTaskID"
-
 -- | Warnings for the math library
 mathWarnings :: AParser String
 mathWarnings =
@@ -196,7 +189,6 @@ deprecatedSequence opts =
               -- Deprecated meta functions
               try metaFuncWarnings
                 -- Library functions
-                <|> try aiWarnings
                 <|> try mathWarnings
                 <|> try spawnmenuWarnings
                 <|> try stringWarnings


### PR DESCRIPTION
Removes the "function is broken" warnings for `ai.GetTaskID` and `ai.GetScheduleID`. Both of these functions were fixed 7 years ago in 2019, they now work as expected.